### PR TITLE
Handle nested tasks

### DIFF
--- a/lib/zone.js
+++ b/lib/zone.js
@@ -26,17 +26,20 @@ function Task(zone, fn, catchErrors, nestedTask){
 Task.prototype.run = function(ctx, args){
 	var previousZone = Zone.current;
 	var zone = Zone.current = this.zone;
-	zone.execHook("beforeTask", this);
+	if(!this.nestedTask)
+		zone.execHook("beforeTask", this);
 
 	var res;
 	try {
 		zone.runningTask = true;
 		res = this.fn.apply(ctx, args);
 		Zone.current = previousZone;
-		zone.execHook("afterTask", this);
+		if(!this.nestedTask)
+			zone.execHook("afterTask", this);
 	} catch(err) {
 		Zone.current = previousZone;
-		zone.execHook("afterTask", this);
+		if(!this.nestedTask)
+			zone.execHook("afterTask", this);
 		if(this.catchErrors !== false) {
 			zone.errors.push(err);
 		} else {
@@ -143,7 +146,7 @@ Zone.ignore = function(fn){
 	return zone.ignore(fn);
 };
 
-Zone.prototype.runTask = function(fn, ctx, args, catchErrors){
+Zone.prototype.runTask = function(fn, ctx, args, catchErrors, decrementWaits){
 	var res, error;
 	var alreadyRunning = this.runningTask;
 	var task = new Task(this, fn, catchErrors, alreadyRunning);
@@ -152,7 +155,7 @@ Zone.prototype.runTask = function(fn, ctx, args, catchErrors){
 	} catch(err) {
 		error = err;
 	}
-	if(this.removeWait)
+	if(decrementWaits && this.removeWait)
 		this.removeWait();
 	if(error)
 		throw error;
@@ -216,9 +219,13 @@ Zone.prototype.end = function(){
 	}
 };
 
-Zone.prototype.wrapAndWait = function(){
+Zone.prototype.wrapAndWait = function(fn, catchErrors){
 	this.addWait();
-	return this.wrap.apply(this, arguments);
+	var zone = this;
+
+	return function(){
+		return zone.runTask(fn, this, arguments, catchErrors, true);
+	};
 };
 
 Zone.prototype.ignore = function(fn){

--- a/test/test.js
+++ b/test/test.js
@@ -155,6 +155,20 @@ describe("new Zone", function(){
 			assert.equal(data.foo, "bar", "data was added in the end");
 		}).then(done, done);
 	});
+
+	it("Zone hooks are called once per async task", function(done){
+		var times = 0;
+		new Zone({
+			beforeTask: function(){
+				times++;
+			}
+		}).run(function(){
+			var fn = Zone.current.wrap(function(){});
+			fn();
+		}).then(function(){
+			assert.equal(times, 1, "Hook called once");
+		}).then(done, done);
+	});
 });
 
 describe("setTimeout", function(){


### PR DESCRIPTION
Tasks are said to be nested when they are called within the code of
another task. This is a problem because it means we would be executing
lifecycle hooks more than once per async operation, which can lead to
hooks doing the wrong thing (a beforeTask could be called twice, where
		before/after tasks are meant to do setup/teardown). Closes #53