### PR TITLE
Execute afterTasks in reverse order

### DIFF
--- a/lib/zone.js
+++ b/lib/zone.js
@@ -35,11 +35,11 @@ Task.prototype.run = function(ctx, args){
 		res = this.fn.apply(ctx, args);
 		Zone.current = previousZone;
 		if(!this.nestedTask)
-			zone.execHook("afterTask", this);
+			zone.execHookR("afterTask", this);
 	} catch(err) {
 		Zone.current = previousZone;
 		if(!this.nestedTask)
-			zone.execHook("afterTask", this);
+			zone.execHookR("afterTask", this);
 		if(this.catchErrors !== false) {
 			zone.errors.push(err);
 		} else {
@@ -199,6 +199,19 @@ Zone.prototype.execHook = function(hook /* , args */){
 	}
 };
 
+Zone.prototype.execHookR = function(hook /* , args */){
+	var args = slice.call(arguments, 1);
+	var zone = this;
+	var prop = hook + "s";
+	var array = this[prop];
+	if(array){
+		var i = array.length - 1;
+		for(; i >= 0; i--) {
+			array[i].apply(zone, args);
+		}
+	}
+};
+
 Zone.prototype.wrap = function(fn, catchErrors){
 	var zone = this;
 
@@ -238,7 +251,7 @@ Zone.prototype.ignore = function(fn){
 		// Use the original versions
 		var task = new Task(zone);
 
-		zone.execHook("afterTask", task);
+		zone.execHookR("afterTask", task);
 		var res = fn.apply(this, arguments);
 		zone.execHook("beforeTask", task);
 		return res;

--- a/test/test.js
+++ b/test/test.js
@@ -169,6 +169,45 @@ describe("new Zone", function(){
 			assert.equal(times, 1, "Hook called once");
 		}).then(done, done);
 	});
+
+	it("Correctly unwraps globals", function(done){
+		var g = env.global;
+		g.FOO = "bar";
+
+		var a = function(){
+			var old;
+			return {
+				beforeTask: function(){
+					old = g.FOO;
+					g.FOO = "a";
+				},
+				afterTask: function(){
+					g.FOO = old;
+				}
+			};
+		};
+
+		var b = function(){
+			var old;
+			return {
+				beforeTask: function(){
+					old = g.FOO;
+					g.FOO = "b";
+				},
+				afterTask: function(){
+					g.FOO = old;
+				}
+			};
+		};
+
+		new Zone({
+			plugins: [a, b]
+		}).run(function(){}).then(function(){
+			assert.equal(g.FOO, "bar", "Global was restored");
+			delete g.FOO;
+			done();
+		});
+	});
 });
 
 describe("setTimeout", function(){


### PR DESCRIPTION
This is needed so that the first plugin that is called in the beforeTask
is the last to be executed in the afterTask. This ensures that globals
are restored to their previous value. Closes #55