### PR TITLE
XHR Browser interception, set status code

### DIFF
--- a/lib/zones/xhr.js
+++ b/lib/zones/xhr.js
@@ -123,7 +123,7 @@ function setResponse(xhr, response){
 		value: response.responseText
 	});
 	util.defineProperty(xhr, "status", {
-		value: xhr.status
+		value: response.status
 	});
 	xhr.getAllResponseHeaders = function(){
 		return response.headers;


### PR DESCRIPTION
This fixes the browser side interception so that it properly sets the
status code from the server. Closes #58 