### PR TITLE
Always mark a task as being nested

### DIFF
--- a/lib/zone.js
+++ b/lib/zone.js
@@ -17,11 +17,11 @@ function Deferred(){
 	});
 }
 
-function Task(zone, fn, catchErrors, nestedTask){
+function Task(zone, fn, catchErrors){
 	this.zone = zone;
 	this.fn = fn;
 	this.catchErrors = catchErrors;
-	this.nestedTask = nestedTask;
+	this.nestedTask = zone.runningTask;
 }
 
 Task.prototype.run = function(ctx, args){
@@ -161,8 +161,7 @@ Zone.ignore = function(fn){
 
 Zone.prototype.runTask = function(fn, ctx, args, catchErrors, decrementWaits){
 	var res, error;
-	var alreadyRunning = this.runningTask;
-	var task = new Task(this, fn, catchErrors, alreadyRunning);
+	var task = new Task(this, fn, catchErrors);
 	try {
 		res = task.run(ctx, args);
 	} catch(err) {

--- a/test/test.js
+++ b/test/test.js
@@ -405,6 +405,22 @@ if(isBrowser) {
 				.then(done);
 			});
 		});
+
+		it("can run a Promise within the callback", function(done){
+			var zone = new Zone();
+			zone.run(function(){
+				var xhr = new XMLHttpRequest();
+				xhr.open("GET", "http://chat.donejs.com/api/messages");
+				xhr.onload = function(){
+					Promise.resolve().then(function(){
+						Zone.current.data.worked = true;
+					});
+				};
+				xhr.send();
+			}).then(function(data){
+				assert.equal(data.worked, true, "got to the then");
+			}).then(done, done);
+		});
 	});
 }
 


### PR DESCRIPTION
Instead of passing whether a task is nested within the constructor,
		which could lead to forgetting to pass this parameter, instead
		determine based on whether `zone.runningTask` is true. This
		prevents cycles.