### PR TITLE
Allow not passing in function into Zone.waitFor

### DIFF
--- a/lib/zone.js
+++ b/lib/zone.js
@@ -8,6 +8,7 @@ var forEach = require("./util").forEach;
 require("../register");
 
 var slice = Array.prototype.slice;
+var noop = function(){};
 
 function Deferred(){
 	var dfd = this;
@@ -130,6 +131,7 @@ function Zone(spec) {
 }
 
 Zone.waitFor = function(fn, catchErrors){
+	fn = fn || noop;
 	var zone = Zone.current;
 	if(!zone) return fn;
 	return zone.waitFor(fn, catchErrors);

--- a/test/test.js
+++ b/test/test.js
@@ -604,6 +604,19 @@ describe("Zone.waitFor", function(){
 			assert(!Zone.current, "There is no current Zone");
 		}).then(done, done);
 	});
+
+	it("do not need to pass in a function for it to work", function(done){
+		new Zone().run(function(){
+			var d = Zone.waitFor();
+
+			setTimeout(function(){
+				d();
+			});
+		})
+		.then(function(){
+			done();
+		}, done);
+	});
 });
 
 describe("Zone.error", function(){


### PR DESCRIPTION
This way you can do stuff like:

```js
var done = Zone.waitFor();

// do some c++ stuff in node
done();
```