### PR TITLE
Properly handle promise rejection chains

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -52,22 +52,27 @@ exports.requestAnimationFrame = function(rAF){
 exports.then = function(then){
 	return function(onFulfilled, onRejected){
 		var fn;
+		var rejected;
 		var callback = Zone.current.waitFor(function(val){
 			if(fn) {
 				return fn.apply(this, arguments);
+			} else if(rejected) {
+				val = typeof val === "string" ? new Error(val) : val;
+				throw val;
 			}
 			return val;
 		}, false);
 
-		var callWith = function(cb){
+		var callWith = function(cb, isError){
 			return function(){
 				fn = cb;
+				rejected = !!isError;
 				return callback.apply(this, arguments);
 			};
 		};
 
 		return then.call(this, callWith(onFulfilled),
-						 callWith(onRejected));
+						 callWith(onRejected, true));
 	};
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -579,6 +579,37 @@ describe("Promises", function(){
 			assert.equal(data.response, "hello", "got the value");
 		}).then(done);
 	});
+
+	it("Throwing a string works", function(done){
+		new Zone().run(function(){
+
+			Promise.reject("uh oh").then().then(null, function(err){
+				Zone.current.data.reason = err.message;
+			});
+
+		}).then(function(data){
+			assert.equal(data.reason, "uh oh", "got the reason for the rejection");
+			done();
+		});
+	});
+
+	if(typeof System === "object" && !!System.import) {
+		it("Rejects an import for a file that doesn't exist", function(done){
+			new Zone().run(function(){
+				var p = System.import("fake/module");
+
+				p.then(function(mod){
+					Zone.error(new Error("import worked when it should not have"));
+				}, function(err){
+					Zone.current.data.worked = true;
+				});
+
+			}).then(function(data){
+				assert.ok(data.worked, "it rejected like it should have");
+				done();
+			}, done);
+		});
+	}
 });
 
 describe("Zone.waitFor", function(){


### PR DESCRIPTION
This updates the Promise wrapping to properly handle rejection chains.
If some code throws a string we should wrap it in an Error and rethrow
it. This fixes a bug where `System.import`s that are rejected were not
having their rejection bubble up.