### PR TITLE
Implement can-zone/timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,29 @@ The ZoneSpec defines the following hooks:
 
 Called when the zone is first created, after all ZoneSpecs have been parsed. this is useful if you need to do setup behavior that covers the entire zone lifecycle.
 
+```js
+new Zone({
+	created: function(){
+		// Called as soon as `new Zone` is called
+	}
+});
+```
+
+#### beforeRun
+
+Called immediately before the **Zone.prototype.run** function is called.
+
+```js
+var zone = new Zone({
+	beforeRun: function(){
+		// Setup that needs to happen immediately before running
+		// the zone function
+	}
+});
+
+zone.run(function() { ... });
+```
+
 #### beforeTask
 
 Called before each Task is called. Use this to override any globals you want to exist during the execution of the task:
@@ -244,6 +267,45 @@ new Zone({
 #### ended
 
 Called when the Zone has ended and is about to exit (it's Promise will resolve).
+
+#### hooks
+
+**hooks** allows you to specify custom hooks that your plugin calls. This is mostly to communicate between plugins that inherit each other.
+
+```js
+var barZone = {
+	created: function(){
+		this.execHook("beforeBar");
+	},
+
+	hooks: ["beforeBar"]
+};
+
+var fooZone = {
+	beforeBar: function(){
+		// Called!
+	},
+	plugins: [barZone]
+};
+
+new Zone({
+	plugins: [fooZone]
+});
+
+zone.run(function() { ... });
+```
+
+### Zones
+
+**can-zone** comes with the following Zone plugins:
+
+#### xhr
+
+Allows you to instrument XHR.
+
+#### [timeout](https://github.com/canjs/can-zone/blob/master/docs/zones/timeout.md)
+
+Allows you to specify a timeout for the Zone, to prevent waiting indefinitely.
 
 ## License
 

--- a/docs/zones/timeout.md
+++ b/docs/zones/timeout.md
@@ -1,0 +1,31 @@
+# can-zone/timeout
+
+The timeout zone allows you to specify a timeout for your Zone. If the Zone promise doesn't resolve before timing out, the Zone promise will be rejected by the plugin.
+
+The **timeout** zone is a function that takes a timeout in milliseconds.
+
+The Promise will reject with a special type of Error, a **TimeoutError**.
+
+```js
+var Zone = require("can-zone");
+var timeout = require("can-zone/timeout");
+var TimeoutError = timeout.TimeoutError;
+
+var zone = new Zone({
+	plugins: [
+		timeout(2000)
+	]
+});
+
+zone.run(function(){
+
+	setTimeout(function(){
+
+	}, 5000);
+
+}).then(null, function(err){
+
+	// err.timeout -> 2000
+
+});
+```

--- a/lib/zone.js
+++ b/lib/zone.js
@@ -59,7 +59,8 @@ var hooks = [
 	"beforeTask",
 	"afterTask",
 	"created",
-	"ended"
+	"ended",
+	"beforeRun"
 ];
 
 var commonGlobals = [
@@ -180,6 +181,8 @@ Zone.prototype.run = function(fn){
 	if(this.isResolved) {
 		this.deferred = new Deferred();
 		this.isResolved = false;
+	} else {
+		this.execHook("beforeRun");
 	}
 
 	var task = new Task(this, fn);

--- a/lib/zone.js
+++ b/lib/zone.js
@@ -94,7 +94,11 @@ function buildZoneSpec(zone, spec, plugins, processedSpecs){
 		buildZoneSpec(zone, plugin, null, processedSpecs);
 	});
 
-	forEach.call(hooks, function(hook){
+	if(spec.hooks) {
+		zone.hooks = zone.hooks.concat(spec.hooks);
+	}
+
+	forEach.call(zone.hooks, function(hook){
 		var propName = hook + "s";
 		var array = zone[propName];
 		if(!array) {
@@ -125,6 +129,7 @@ function Zone(spec) {
 	this.data = {};
 	this.globals = {};
 	this.parent = Zone.current;
+	this.hooks = slice.call(hooks);
 
 	buildZoneSpec(this, spec, [globalsZone]);
 

--- a/lib/zones/timeout.js
+++ b/lib/zones/timeout.js
@@ -1,0 +1,44 @@
+module.exports = function(){
+	var timeout, timeoutId, dfd;
+	var zoneRunning = false;
+
+	var startTimer = (function(){
+		var started = false;
+		return function(){
+			if(started || !zoneRunning) {
+				return;
+			}
+			timeoutId = setTimeout(function(){
+				dfd.resolve();
+			}, timeout);
+		};
+	})();
+
+	return {
+		created: function(){
+			dfd = new Deferred();
+			this.timeout = function(ms){
+				timeout = ms;
+				startTimer();
+				return dfd.promise;
+			};
+		},
+
+		beforeRun: function(){
+			zoneRunning = true;
+			startTimer();
+		},
+
+		ended: function(){
+			clearTimeout(timeoutId);
+		}
+	};
+};
+
+function Deferred(){
+	var dfd = this;
+	this.promise = new Promise(function(resolve, reject){
+		dfd.resolve = resolve;
+		dfd.reject = reject;
+	});
+}

--- a/lib/zones/timeout.js
+++ b/lib/zones/timeout.js
@@ -1,44 +1,34 @@
-module.exports = function(){
-	var timeout, timeoutId, dfd;
-	var zoneRunning = false;
+exports = module.exports = function(timeout){
+	if(typeof timeout !== "number") {
+		throw new Error("Must provide a timeout in milliseconds");
+	}
 
-	var startTimer = (function(){
-		var started = false;
-		return function(){
-			if(started || !zoneRunning) {
-				return;
-			}
-			timeoutId = setTimeout(function(){
-				dfd.resolve();
-			}, timeout);
+	return function(data){
+		var timeoutId;
+
+		return {
+			beforeRun: function(){
+				var zone = this;
+				timeoutId = setTimeout(function(){
+					zone.execHook("beforeTimeout");
+					zone.errors.unshift(new TimeoutError(timeout));
+					zone.end();
+				}, timeout);
+			},
+
+			ended: function(){
+				clearTimeout(timeoutId);
+			},
+
+			hooks: ["beforeTimeout"]
 		};
-	})();
-
-	return {
-		created: function(){
-			dfd = new Deferred();
-			this.timeout = function(ms){
-				timeout = ms;
-				startTimer();
-				return dfd.promise;
-			};
-		},
-
-		beforeRun: function(){
-			zoneRunning = true;
-			startTimer();
-		},
-
-		ended: function(){
-			clearTimeout(timeoutId);
-		}
 	};
 };
 
-function Deferred(){
-	var dfd = this;
-	this.promise = new Promise(function(resolve, reject){
-		dfd.resolve = resolve;
-		dfd.reject = reject;
-	});
-}
+var TimeoutError = exports.TimeoutError = function(timeout){
+	Error.call(this, "This zone exceeded a timeout of", timeout);
+	this.timeout = timeout;
+};
+
+TimeoutError.prototype = new Error();
+TimeoutError.prototype.constructor = TimeoutError;

--- a/test/test.js
+++ b/test/test.js
@@ -804,5 +804,6 @@ describe("Zone.ignore", function(){
 	});
 });
 
-// Require other things
+// Require other tests
 require("./xhr");
+require("./timeout_test");

--- a/test/timeout_test.js
+++ b/test/timeout_test.js
@@ -1,0 +1,69 @@
+var assert = require("assert");
+var timeoutZone = require("../timeout");
+
+describe("Timeout Zone", function(){
+
+	it("Creates a timeout function", function(){
+		var zone = new Zone(timeoutZone);
+
+		assert.equal(typeof zone.timeout, "function",
+			   "The timeout zone created a timeout method");
+	});
+
+	it("timeoutPromise resolves when the timeout is exceeded", function(done){
+		var zone = new Zone(timeoutZone);
+		var timeoutPromise = zone.timeout(10);
+		var runPromise = zone.run(function(){
+			setTimeout(function(){}, 15);
+		});
+
+		var timedOut = false;
+		timeoutPromise.then(function(){
+			timedOut = true;
+		});
+
+		runPromise.then(function(){
+			assert.ok(timedOut, "This timed out before run finished");
+		}).then(done);
+	});
+
+	it("timeoutPromise never resolves if run does complete", function(done){
+		var zone = new Zone(timeoutZone);
+		var timeoutPromise = zone.timeout(10);
+		var runPromise = zone.run(function(){
+			setTimeout(function(){});
+		});
+
+		var timedOut = false;
+		timeoutPromise.then(function(){
+			timedOut = true;
+		});
+		runPromise.then(function(){
+			assert.ok(!timedOut, "Didn't time out");
+
+			// Wait past the timeout
+			setTimeout(function(){
+				assert.ok(!timedOut, "Still did not timeout");
+				done();
+			}, 20);
+		});
+	});
+
+	it(".timeout can be called after .run", function(done){
+		var zone = new Zone(timeoutZone);
+		var runPromise = zone.run(function(){
+			setTimeout(function(){}, 15);
+		});
+		var timeoutPromise = zone.timeout(10);
+
+		var timedOut = false;
+		timeoutPromise.then(function(){
+			timedOut = true;
+		});
+
+		runPromise.then(function(){
+			assert.ok(timedOut, "It timed out");
+			done();
+		});
+	});
+});

--- a/test/timeout_test.js
+++ b/test/timeout_test.js
@@ -1,69 +1,87 @@
 var assert = require("assert");
 var timeoutZone = require("../timeout");
+var TimeoutError = timeoutZone.TimeoutError;
 
 describe("Timeout Zone", function(){
 
-	it("Creates a timeout function", function(){
-		var zone = new Zone(timeoutZone);
+	describe("Calling the plugin", function(){
+		it("Returns a ZoneSpec function", function(){
+			var zonePlugin = timeoutZone(10);
+			assert.equal(typeof zonePlugin, "function", "Returns a function");
+		});
 
-		assert.equal(typeof zone.timeout, "function",
-			   "The timeout zone created a timeout method");
+		it("Throws if you do not provide it a timeout", function(){
+			assert.throws(function(){
+				timeoutZone();
+			}, "Must provide a timeout in milliseconds");
+		});
+
+		it("Works with a timeout of 0", function(){
+			assert.doesNotThrow(function(){
+				timeoutZone(0);
+			});
+		});
 	});
 
-	it("timeoutPromise resolves when the timeout is exceeded", function(done){
-		var zone = new Zone(timeoutZone);
-		var timeoutPromise = zone.timeout(10);
-		var runPromise = zone.run(function(){
+	it("Zone is rejected when the timeout is exceeded", function(done){
+		var zone = new Zone(timeoutZone(10));
+		zone.run(function(){
 			setTimeout(function(){}, 15);
-		});
-
-		var timedOut = false;
-		timeoutPromise.then(function(){
-			timedOut = true;
-		});
-
-		runPromise.then(function(){
-			assert.ok(timedOut, "This timed out before run finished");
-		}).then(done);
+		}).then(null, function(err){
+			assert.ok(err instanceof TimeoutError, "Error is a TimeoutError");
+		}).then(done, done);
 	});
 
-	it("timeoutPromise never resolves if run does complete", function(done){
-		var zone = new Zone(timeoutZone);
-		var timeoutPromise = zone.timeout(10);
-		var runPromise = zone.run(function(){
+	it("Zone is resolved if it beats the timeout", function(done){
+		var zone = new Zone(timeoutZone(10));
+		zone.run(function(){
 			setTimeout(function(){});
-		});
-
-		var timedOut = false;
-		timeoutPromise.then(function(){
-			timedOut = true;
-		});
-		runPromise.then(function(){
-			assert.ok(!timedOut, "Didn't time out");
-
-			// Wait past the timeout
-			setTimeout(function(){
-				assert.ok(!timedOut, "Still did not timeout");
-				done();
-			}, 20);
+		}).then(function(){
+			done();
+		}, function(err){
+			done(err);
 		});
 	});
 
-	it(".timeout can be called after .run", function(done){
-		var zone = new Zone(timeoutZone);
-		var runPromise = zone.run(function(){
-			setTimeout(function(){}, 15);
-		});
-		var timeoutPromise = zone.timeout(10);
+	it("defines a beforeTimeout hook that is called just prior to a timeout", function(done){
+		var myZone = function(data){
+			return {
+				beforeTimeout: function(){
+					data.worked = true;
+				},
+				plugins: [timeoutZone(10)]
+			}
+		};
 
-		var timedOut = false;
-		timeoutPromise.then(function(){
-			timedOut = true;
+		var zone = new Zone(myZone);
+		zone.run(function(){
+			setTimeout(function(){}, 50);
+		}).then(null, function(){
+			assert.ok(zone.data.worked, "it worked");
+		}).then(done, done);
+	});
+
+	it("works in a nested Zone", function(done){
+		var zone = new Zone(timeoutZone(10));
+		var innerPromise;
+
+		var outerPromise = zone.run(function(){
+			innerPromise = new Zone().run(function(){
+				setTimeout(function(){}, 20);
+			});
 		});
 
-		runPromise.then(function(){
-			assert.ok(timedOut, "It timed out");
-			done();
+		assert.ok(innerPromise, "inner promise is immediately defined");
+
+		Promise.race([
+			innerPromise,
+			outerPromise
+		]).then(null, function(err){
+			assert.ok(err instanceof TimeoutError, "it timed out");
+			innerPromise.then(function(){
+				assert.ok("inner eventually completed");
+				done();
+			});
 		});
 	});
 });

--- a/timeout.js
+++ b/timeout.js
@@ -1,0 +1,1 @@
+module.exports = require("./lib/zones/timeout");


### PR DESCRIPTION
This adds `can-zone/timeout` a plugin to create timeouts for when a Zone
should be completed.

You use it like:
```js
var timeout = require("can-zone/timeout");
var TimeoutError = timeout.TimeoutError;

var zone = new Zone({
	plugins: [timeout(5000)]
});

zone.run(function(){
	setTimeout(function(){}, 10000);
}).catch(function(err){

	// err instanceof TimeoutError

});
```