### PR TITLE
Makes the xhr plugin work in Safari

### DIFF
--- a/lib/zones/xhr.js
+++ b/lib/zones/xhr.js
@@ -4,21 +4,72 @@ var util = require("../util");
 module.exports = env.isNode ? nodeZone : browserZone;
 
 var WAIT_URL = util.symbol("__canWaitURL");
+var REAL_XHR = util.symbol("__xhr");
 
 function browserZone(data){
-	var cache, oldOpen, oldSend;
+	var cache, oldXHR;
+	//var cache, oldOpen, oldSend;
 
-	var open = function(method, url){
+	var propsToIgnore = { onreadystatechange: true, onload: true, __events: true };
+	// Copy props from source to dest, except those on the XHR prototype and
+	// listed as excluding.
+	var assign = function(dest, source, excluding){
+		excluding = excluding || {};
+
+		// copy everything on this to the xhr object that is not on `this`'s prototype
+		for(var prop in source){
+			if(!( prop in XHR.prototype) && !excluding[prop] ) {
+				dest[prop] = source[prop];
+			}
+		}
+	};
+
+	var callParent = function(proto, props) {
+		var i = 0, len = props.length;
+		var addMethod = function(method){
+			proto[method] = function(){
+				var xhr = this[REAL_XHR];
+				return xhr[method].apply(xhr, arguments);
+			};
+		};
+		for(; i < len; i++) {
+			addMethod(props[i]);
+		}
+	};
+
+	var XHR = function(){
+		var xhr = this[REAL_XHR] = new oldXHR();
+
+		this.onload = null;
+		this.onerror = null;
+
+		assign(this, xhr, propsToIgnore);
+	};
+
+	callParent(XHR.prototype, [
+		"setRequestHeader",
+		"getAllResponseHeaders",
+		"addEventListener",
+		"removeEventListener",
+		"getResponseHeader"
+	]);
+
+	XHR.prototype.open = function(method, url){
 		util.defineProperty(this, WAIT_URL, {
 			value: url,
 			enumerable: false
 		});
-		return oldOpen.apply(this, arguments);
+		return this[REAL_XHR].open.apply(this._xhr, arguments);
 	};
 
-	var send = function(){
+	XHR.prototype.send = function(){
+		var realXhr = this[REAL_XHR];
+		var fakeXhr = this;
+		assign(realXhr, this, propsToIgnore);
+
 		var data, response;
 		var url = this[WAIT_URL];
+
 		for(var i = 0, len = cache.length; i < len; i++) {
 			data = cache[i];
 			if(data.request.url === url) {
@@ -35,24 +86,42 @@ function browserZone(data){
 			}, 0);
 			return;
 		}
-		return oldSend.apply(this, arguments);
+
+		var onreadystatechange = fakeXhr.onreadystatechange;
+		realXhr.onreadystatechange = function(){
+			assign(fakeXhr, realXhr, propsToIgnore);
+			if(onreadystatechange) {
+				return onreadystatechange.apply(fakeXhr, arguments);
+			}
+		};
+		var onload = fakeXhr.onload;
+		if(onload) {
+			realXhr.onload = function(){
+				return onload.apply(fakeXhr, arguments);
+			};
+		}
+		var onerror = fakeXhr.onerror;
+		if(onerror) {
+			realXhr.onerror = function(){
+				return onerror.apply(fakeXhr, arguments);
+			};
+		}
+		return realXhr.send.apply(realXhr, arguments);
 	};
 
 	return {
 		beforeTask: function(){
 			cache = env.global.XHR_CACHE;
-			if(cache) {
-				oldOpen = XMLHttpRequest.prototype.open;
-				oldSend = XMLHttpRequest.prototype.send;
-				XMLHttpRequest.prototype.open = open;
-				XMLHttpRequest.prototype.send = send;
+			if(cache && cache.length) {
+			   oldXHR = XMLHttpRequest;
+			   env.global.XMLHttpRequest = XHR;
 			}
 		},
 
 		afterTask: function(){
-			if(cache) {
-				XMLHttpRequest.prototype.open = oldOpen;
-				XMLHttpRequest.prototype.send = oldSend;
+			cache = env.global.XHR_CACHE;
+			if(cache && cache.length) {
+				env.global.XMLHttpRequest = oldXHR;
 			}
 		}
 	};

--- a/test/debug_test.js
+++ b/test/debug_test.js
@@ -72,7 +72,7 @@ describe("Debug Zone", function(){
 		}).then(done, done);
 	});
 
-	it.only("Includes debug info for the tasks that did not complete", function(done){
+	it("Includes debug info for the tasks that did not complete", function(done){
 		var zone = new Zone(debugZone(20));
 
 		zone.run(function(){

--- a/test/xhr.js
+++ b/test/xhr.js
@@ -118,6 +118,128 @@ if(env.isNode) {
 			});
 		});
 
+		describe("Without XHR Cache", function(){
+			beforeEach(function(){
+				this.oldXHR = XMLHttpRequest;
+				var XHR = g.XMLHttpRequest = function(){};
+				XHR.prototype.open = function(){};
+				XHR.prototype.send = function(){
+					var onreadystatechange = this.onreadystatechange;
+					var onload = this.onload;
+					var xhr = this;
+					xhr.readyState = 4;
+					setTimeout(function(){
+						xhr.status = 200;
+						xhr.responseText = '{"foo":"bar"}';
+						var ev = { target: xhr };
+						onreadystatechange.call(xhr, ev);
+						onload.call(xhr, ev);
+					}, 5);
+				};
+				g.XHR_CACHE = [{request:{url:""}}];
+			});
+
+			afterEach(function(){
+				XMLHttpRequest.prototype.open = this.oldOpen;
+				delete g.XHR_CACHE;
+			});
+
+			it("Calls the real xhr.send", function(done){
+				var app = function(){
+					var xhr = new XMLHttpRequest();
+					xhr.open("GET", "foo://bar");
+					xhr.onload = function(){
+						var resp = JSON.parse(xhr.responseText);
+						Zone.current.data.worked = resp.foo === "bar";
+					};
+					xhr.send();
+				};
+
+				new Zone(xhrZone).run(app).then(function(data){
+					assert.ok(data.worked, "it loaded without the cache");
+				}).then(done, done);
+			});
+		});
+
+		describe("XHR methods", function(){
+			beforeEach(function(){
+				g.XHR_CACHE = [{request:{url:""}}];
+				this.oldXHR = g.XMLHttpRequest;
+				var XHR = g.XMLHttpRequest = function(){};
+				XHR.prototype.open = function(){};
+				XHR.prototype.setRequestHeader = function(){
+					Zone.current.data.worked = true;
+				};
+				XHR.prototype.getAllResponseHeaders = function(){
+					return "foo";
+				};
+				XHR.prototype.addEventListener =
+				XHR.prototype.removeEventListener = function(){};
+				XHR.prototype.getResponseHeader = function(){
+					return "bar";
+				};
+			});
+
+			afterEach(function(){
+				delete g.XHR_CACHE;
+				g.XMLHttpRequest = this.oldXHR;
+			});
+
+			it("Supports setRequestHeader", function(done){
+				var zone = new Zone(xhrZone);
+				zone.run(function(){
+					var xhr = new XMLHttpRequest();
+					xhr.setRequestHeader("foo", "bar");
+				}).then(function(data){
+					assert.ok(data.worked, "Called the real setRequestHeader");
+					done();
+				}, done);
+			});
+
+			it("Supports getAllResponseHeaders", function(done){
+				var zone = new Zone(xhrZone);
+				zone.run(function(){
+					var xhr = new XMLHttpRequest();
+					var headers = xhr.getAllResponseHeaders();
+					assert.equal(headers, "foo");
+				}).then(function(){
+					done();
+				}, done);
+			});
+
+			it("Supports addEventListener", function(done){
+				var zone = new Zone(xhrZone);
+				zone.run(function(){
+					var xhr = new XMLHttpRequest();
+					xhr.addEventListener("load", function(){});
+				}).then(function(){
+					done();
+				}, done);
+			});
+
+			it("Supports removeEventListener", function(done){
+				var zone = new Zone(xhrZone);
+				zone.run(function(){
+					var xhr = new XMLHttpRequest();
+					xhr.removeEventListener("load", function(){});
+				}).then(function(){
+					done();
+				}, done);
+			});
+
+			it("Supports getResponseHeader", function(done){
+				var zone = new Zone(xhrZone);
+				zone.run(function(){
+					var xhr = new XMLHttpRequest();
+					var d = xhr.getResponseHeader("foo");
+					assert.equal(d, "bar");
+				}).then(function(){
+					done();
+				}, done);
+
+			});
+		});
+
 		describe("Errors", function(){
 			beforeEach(function(){
 				this.oldOpen = XMLHttpRequest.prototype.open;


### PR DESCRIPTION
Previously we were only override `XMLHttpRequest.prototype.send` and
then setting the `status` and `responseText` properties. This works in
other browsers using `defineProperty` but Safari does not allow setting
these props at all. So had to resort to creating a fake XHR object.