### PR TITLE
Flesh out the API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+doc/

--- a/README.md
+++ b/README.md
@@ -61,20 +61,133 @@ For can-zone to work we have to override various task-creating functionality, th
 
 ## API
 
-In Node there are various async methods that do not fall into the most common macrotasks, but still might need to be tracked. To accomodate this we expose a global `Zone.waitFor` function that can be used to wait on the outcome of an asynchronous request.
+- <code>[__can-zone__ function](#can-zone-function)</code>
+  - <code>[new Zone()](#new-zone)</code>
+  - <code>[new Zone(zoneSpec)](#new-zonezonespec)</code>
+    - _static_
+      - <code>[Zone.waitFor(fn)](#zonewaitforfn)</code>
+      - <code>[Zone.current](#zonecurrent)</code>
+      - <code>[Zone.ignore(fn)](#zoneignorefn)</code>
+      - <code>[Zone.error(err)](#zoneerrorerr)</code>
+    - _prototype_
+      - <code>[zone.run(fn)](#zonerunfn)</code>
+      - <code>[zone.data](#zonedata)</code>
+      - <code>[zone.addWait()](#zoneaddwait)</code>
+      - <code>[zone.removeWait()](#zoneremovewait)</code>
+    - _types_
+      - <code>[ZoneSpec Object](#zonespec-object)</code>
+      - <code>[makeZoneSpec function([data](#zonedata))](#makezonespec-functiondatazonedata)</code>
+    - _modules_
+      - <code>[__can-zone/register__ function](#can-zoneregister-function)</code>
+    - _plugins_
+      - <code>[__can-zone/timeout__ function(ms)](#can-zonetimeout-functionms)</code>
+        - <code>[timeout(ms)](#timeoutms)</code>
+          - <code>[TimeoutError Error](#timeouterror-error)</code>
+      - <code>[__can-zone/debug__ function](#can-zonedebug-function)</code>
+        - <code>[debug(ms)](#debugms)</code>
+        - <code>[debug(timeoutZone)](#debugtimeoutzone)</code>
+          - <code>[DebugInfo Array\<Object\>](#debuginfo-arrayobject)</code>
+
+## <code>__can-zone__ function</code>
+
+
+
+### <code>new Zone()</code>
+
+
+Creates a new Zone with no additional overrides. Can then call [zone.run](#zonerunfn) to call a function within the Zone.
+
+```js
+var Zone = require("can-zone");
+
+var zone = new Zone();
+
+zone.run(function(){
+
+	return "hello world";
+
+}).then(function(data){
+	data.result // -> "hello world"
+});
+```
+
+
+### <code>new Zone(zoneSpec)</code>
+
+
+Create a new Zone using the provided [ZoneSpec](#zonespec-object) to configure the Zone. The following examples configures a Zone that will time out after 5 seconds.
+
+```js
+var Zone = require("can-zone");
+
+var timeoutSpec = function(){
+	var timeoutId;
+
+	return {
+		created: function(){
+			timeoutId = setTimeout(function(){
+				Zone.error(new Error("This took too long!"));
+			}, 5000);
+		},
+		ended: function(){
+			clearTimeout(timeoutId);
+		}
+	};
+};
+
+var zone = new Zone(timeoutSpec);
+```
+
+
+1. __zoneSpec__ <code>{[ZoneSpec](#zonespec-object)|[makeZoneSpec](#makezonespec-functiondatazonedata)([data](#zonedata))}</code>:
+  A [ZoneSpec](#zonespec-object) object or a [function that returns](#makezonespec-functiondatazonedata) a ZoneSpec object.
+  
+  These two are equivalent:
+  
+  ```js
+  new Zone({
+  	created: function(){
+  		
+  	}
+  });
+  
+  new Zone(function(){
+  	return {
+  		created: function(){
+  
+  		}
+  	};
+  });
+  ```
+  
+  The latter form is useful so that you have a closure specific to that [Zone](#new-zone).
+  
+
+#### <code>Zone.waitFor(fn)</code>
+
+
+**Zone.waitFor** is a function that creates a callback that can be used with any async functionality. Calling Zone.waitFor registers a wait with the currently running request and returns a function that, when called, will decrement the wait count.
+
+This is useful if there is async functionality other than what [we implement](#tasks). You might be using a library that has C++ bindings and doesn't go through the normal JavaScript async APIs.
 
 ```js
 var Zone = require("can-zone");
 var fs = require("fs");
 
-fs.readFile("some/file", Zone.waitFor(function(err, file){
-	// We've waited
+fs.readFile("data.json", "utf8", Zone.waitFor(function(){
+	// We waited on this!
 }));
 ```
 
-### Zone.current
 
-Represents the currently running zone. If the code using **Zone.current** is not running within a zone the value will be undefined.
+1. __fn__ <code>{function}</code>:
+  
+  
+
+#### <code>Zone.current</code>
+
+
+Represents the currently running [zone](#new-zone). If the code using **Zone.current** is not running within a zone the value will be undefined.
 
 ```js
 var Zone = require("can-zone");
@@ -88,56 +201,9 @@ myZone.run(function(){
 });
 ```
 
-### Zone.waitFor
 
-**Zone.waitFor** is a function that creates a callback that can be used with any async functionality. Calling Zone.waitFor registers a wait with the currently running request and returns a function that, when called, will decrement the wait count.
+#### <code>Zone.ignore(fn)</code>
 
-This is useful if there is async functionality other than what [we implement](#tasks). You might be using a library that has C++ bindings and doesn't go through the normal JavaScript async APIs.
-
-```js
-var Zone = require("can-zone");
-var asyncThing = require("some-module-that-does-secret-async-stuff");
-
-asyncThing(Zone.waitFor(function(){
-	// We waited on this!
-}));
-```
-
-### Zone.prototype.data
-
-You might want to get data back from can-zone, for example if you are using the library to track asynchronous rendering requests. Each zone contains a **data** object which can be used to store artibitrary values.
-
-```js
-var Zone = require("can-zone");
-
-var xhr = new XMLHttpRequest();
-xhr.open("GET", "http://example.com");
-xhr.onload = function(){
-	// Save this data for later
-	Zone.current.data.xhr = xhr.responseText;
-};
-xhr.send();
-```
-
-### Zone.error
-
-Allows you to add an error to the currently running zone.
-
-```js
-var Zone = require("can-zone");
-
-new Zone().run(function(){
-
-	setTimeout(function(){
-		Zone.error(new Error("oh no"));
-	}, 100);
-
-}).then(null, function(error){
-	error; // -> {message: "oh no"}
-});
-```
-
-### Zone.ignore
 
 Creates a function that, when called, will not track any calls. This might be needed if you are calling code that does unusual things, like using setTimeout recursively indefinitely.
 
@@ -158,158 +224,462 @@ new Zone().run(function(){
 });
 ```
 
-### ZoneSpec
 
-Each zone you create takes a **ZoneSpec** that defines behaviors that will be added to the zone. A common use case is to provide globals that you want to add within the zone. Common globals such as **document**, **window**, and **location** can be placed directly on the zoneSpec, all others within the **globals** object.
+1. __fn__ <code>{function}</code>:
+  A function that contains calls to asynchronous functions that are needing to be ignored.
+  
 
-```js
-var Zone = require("can-zone");
+- __returns__ <code>{function}</code>:
+  A function in which calls to [addWait](#zoneaddwait) and [removeWait](#zoneremovewait) will be ignored, preventing the Zone's promise from remaining unresolved while asynchronous activity continues within.
+  
 
-var zone = new Zone({
-	document: document,
-	globals: {
-		foo: "bar"
-	}
-});
-```
+#### <code>Zone.error(err)</code>
 
-The ZoneSpec can be provided as an object (like above) or a function that returns a ZoneSpec:
+
+Allows you to add an error to the currently running zone.
 
 ```js
 var Zone = require("can-zone");
 
-var zone = new Zone(function(){
-	var foo = "bar";
-	return {
-		beforeTask: function(){
-			global.foo = foo;
-		}
-	}
+new Zone().run(function(){
+
+	setTimeout(function(){
+		Zone.error(new Error("oh no"));
+	}, 100);
+
+}).then(null, function(error){
+	error; // -> {message: "oh no"}
 });
 ```
 
-**Plugins** provide a way to inherit behavior defined in other ZoneSpecs. Here's a plugin that changes the title of your page randomly.
+
+1. __err__ <code>{Error}</code>:
+  
+  
+
+#### <code>zone.run(fn)</code>
+
+
+Runs a function within a [Zone](#new-zone). Calling run will set the Zone's internal Promise which will only resolve once all asynchronous calls within `fn` are complete.
+
+
+1. __fn__ <code>{function}</code>:
+  Any function which needs to run within the Zone. The function will be executed immediately.
+  
+
+- __returns__ <code>{Promise\<[data](#zonedata)\>}</code>:
+  Returns a promise that will resolve with the Zone's [data](#zonedata) object.
+  
+  ```js
+  var zone = new Zone();
+  
+  zone.run(function(){
+  
+  	setTimeout(function(){
+  		zone.data.foo = "bar";
+  	});
+  
+  }).then(function(data){
+  	data.foo // -> "bar"
+  });
+  ```
+  
+
+#### <code>zone.data</code>
+
+
+You might want to get data back from can-zone, for example if you are using the library to track asynchronous rendering requests. Each zone contains a **data** object which can be used to store artibitrary values.
 
 ```js
-var titleZone = function(){
-	return {
-		beforeTask: function(){
-			document.title = Math.random() + " huzzah!";
-		}
+var Zone = require("can-zone");
+
+var xhr = new XMLHttpRequest();
+xhr.open("GET", "http://example.com");
+xhr.onload = function(){
+	// Save this data for later
+	Zone.current.data.xhr = xhr.responseText;
+};
+xhr.send();
+```
+
+
+
+#### <code>zone.addWait()</code>
+
+
+Adds a wait to the [Zone](#new-zone). Adding a wait will delay the Zone's Promise from resolving (the promise created by calling [zone.run](#zonerunfn)) by incrementing its internal counter.
+
+Usually a corresponding [removeWait](#zoneremovewait) will be called to decrement the counter.
+
+```js
+new Zone().run(function(){
+
+	var zone = Zone.current;
+
+	zone.addWait(); // counter at 1
+	zone.removeWait(); // counter at 0, Promise resolves
+
+}).then(function(){
+
+});
+```
+
+
+#### <code>zone.removeWait()</code>
+
+
+Decrements the [Zone's](#new-zone) internal counter that is used to decide when its [run Promise](#zonerunfn) will resolve.
+
+Usually used in conjuction with [addWait](#zoneaddwait). Most of the time you'll want to use [waitFor](#zonewaitforfn), but in some cases where a callback is not enough to know waiting is complete, using addWait/removeWait gives you finer grained control.
+
+```js
+var zone = new Zone();
+
+var obj = new SomeObject();
+
+// This is only done when the event.status is 3
+obj.onprogress = function(ev){
+	if(ev.status === 3) {
+		zone.removeWait();
 	}
 };
+
+zone.addWait();
+```
+
+#### ZoneSpec `{Object}`
+
+ A ZoneSpec is the way you tap into the lifecycle hooks of a [Zone](#new-zone). The hooks are described below.
+
+Using these hooks you can do things like create timers and override global variables that will change the *shape* of code that runs within the Zone.
+
+
+
+
+##### <code>Object</code>
+
+- __created__ <code>{function}</code>:
+  
+  
+  Called when the zone is first created, after all ZoneSpecs have been parsed. this is useful if you need to do setup behavior that covers the entire zone lifecycle.
+  
+  ```js
+  new Zone({
+  	created: function(){
+  		// Called as soon as `new Zone` is called
+  	}
+  });
+  ```
+  
+- __beforeRun__ <code>{function}</code>:
+  
+  
+  Called immediately before the **Zone.prototype.run** function is called.
+  
+  ```js
+  var zone = new Zone({
+  	beforeRun: function(){
+  		// Setup that needs to happen immediately before running
+  		// the zone function
+  	}
+  });
+  
+  zone.run(function() { ... });
+  ```
+  
+- __beforeTask__ <code>{function}</code>:
+  
+  
+  Called before each Task is called. Use this to override any globals you want to exist during the execution of the task:
+  
+  ```js
+  new Zone({
+  	beforeTask: function(){
+  		window.setTimeout = mySpecialSetTimeout;
+  	}
+  });
+  ```
+  
+- __ended__ <code>{function}</code>:
+  
+  
+  Called when the Zone has ended and is about to exit (it's Promise will resolve).
+  
+- __hooks__ <code>{Array\<string\>}</code>:
+  
+  
+  **hooks** allows you to specify custom hooks that your plugin calls. This is mostly to communicate between plugins that inherit each other.
+  
+  ```js
+  var barZone = {
+  	created: function(){
+  		this.execHook("beforeBar");
+  	},
+  
+  	hooks: ["beforeBar"]
+  };
+  
+  var fooZone = {
+  	beforeBar: function(){
+  		// Called!
+  	},
+  	plugins: [barZone]
+  };
+  
+  new Zone({
+  	plugins: [fooZone]
+  });
+  
+  zone.run(function() { ... });
+  ```
+  
+- __plugins__ <code>{Array\<[ZoneSpec](#zonespec-object)|[makeZoneSpec](#makezonespec-functiondatazonedata)([data](#zonedata))\>}</code>:
+  
+  
+  Allows specifying nested [ZoneSpecs](#zonespec-object) that the current depends on. This allows creating rich plugins that depend on other plugins (ZoneSpecs). You can imagine having a bunch of tiny plugins that do one thing and then composing them together into one meta-plugin that is more end-user friendly.
+  
+  Similar to the [Zone](#new-zone) constructor you can either specify [ZoneSpec](#zonespec-object) objects or functions that return ZoneSpec objects. The former gives you a closure specific to the Zone, which is often needed for variables. These two forms are equivalent:
+  
+  ```js
+  var specOne = {
+  	created: function(){
+  
+  	}
+  };
+  
+  var specTwo = function(){
+  	return {
+  		created: function(){
+  
+  		}
+  	}
+  };
+  
+  var zone = new Zone({
+  	plugins: [ specOne, specTwo ]
+  });
+  ```
+  
+#### makeZoneSpec `{function([data](#zonedata))}`
+
+
+A function that returns a [ZoneSpec](#zonespec-object) object. This can be used any place where a [ZoneSpec](#zonespec-object) is accepted.
+
+
+
+##### <code>function([data](#zonedata))</code>
+
+
+1. __data__ <code>{[data](#zonedata)}</code>:
+  The [Zone's](#new-zone) data object, useful when you want to append data to the Zone.
+  
+  This examples wraps [document.createElement](https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement) to keep count of how many elements are created, and appends the count to [data](#zonedata) when the Zone ends.
+  
+  ```js
+  var mySpec = function(data){
+  	var realCreateElement,
+  		count = 0;
+  
+  	return {
+  		beforeTask: function(){
+  			realCreateElement = document.createElement;
+  			document.createElement = function(){
+  				count++;
+  				return realCreateElement.apply(this, arguments);
+  			};
+  		},
+  		afterTask: function(){
+  			document.createElement = realCreateElement;
+  		},
+  		ended: function(){
+  			data.elementsCreated = count;
+  		}
+  	};
+  };
+  
+  var zone = new Zone(mySpec);
+  
+  zone.run(function(){
+  	// Do stuff here
+  })
+  .then(function(data){
+  	data.elementsCreated; // -> 5
+  });
+  ```
+  
+
+- __returns__ <code>{[ZoneSpec](#zonespec-object)}</code>:
+  A [ZoneSpec](#zonespec-object)
+  
+#### can-zone/register `{function}`
+
+ 
+In order to do it's magic, [can-zone](#new-zone) has to register handlers for all of the common JavaScript async operations. If you have code (or a dependency with this code) that does:
+
+```js
+var st = setTimeout;
+```
+
+And this module loads before can-zone, any time `st` is used we won't be able to track that within the Zone.
+
+To work around this, **can-zone/register** is used as a script that you run before any other modules.
+
+### In Node
+
+```js
+require("can-zone/register");
+```
+
+At the top of your entry-point script.
+
+### In the Browser
+
+You can either add a script tag above all others:
+
+```js
+<script src="node_modules/can-zone/register.js"></script>
+```
+
+Or, if you're using a module loader / bundler, configure it so that can-zone/register is placed above all others in the bundle.
+
+
+
+
+##### <code>function()</code>
+
+
+- __returns__ <code>{undefined}</code>:
+  
+
+#### <code>__can-zone/timeout__ function(ms)</code>
+
+
+
+##### <code>timeout(ms)</code>
+
+
+Creates a [ZoneSpec](#zonespec-object) that you can use as a plugin for your [Zone](#new-zone) in order to timeout after a certain length of time (as `ms`).
+
+If the Zone times out it's [run promise](#zonerunfn) will be rejected with a [TimeoutError](#timeouterror-error), a special error that also includes the number of milliseconds waited before timing out.
+
+```js
+var Zone = require("can-zone");
+var timeout = require("can-zone/timeout");
 
 var zone = new Zone({
-	plugins: [titleZone]
+	plugins: [ timeout(5000) ]
+});
+
+zone.run(function(){
+	setTimeout(function(){
+
+	}, 10000); // waiting over 5 sec
+})
+.catch(function(err){
+	// Called because we exceeded the timeout.
 });
 ```
 
-Since plugins are also defined with ZoneSpecs (or functions that return ZoneSpecs) this means you can have plugins that use plugins, that use plugins... We hope that there will be developed "bundles" of plugins that provide robust behaviors.
 
-The ZoneSpec defines the following hooks:
+1. __ms__ <code>{Number}</code>:
+  The number of milliseconds to wait before timing out the [Zone](#new-zone).
+  
 
-#### created
+- __returns__ <code>{[ZoneSpec](#zonespec-object)}</code>:
+  A ZoneSpec that can be passed as a plugin.
+  
+###### TimeoutError `{Error}`
 
-Called when the zone is first created, after all ZoneSpecs have been parsed. this is useful if you need to do setup behavior that covers the entire zone lifecycle.
+A special type of Error that also includes the number of milliseconds that were waited before timing out. 
+The error object is included with the timeout module:
 
 ```js
-new Zone({
-	created: function(){
-		// Called as soon as `new Zone` is called
-	}
-});
+var timeout = require("can-zone/timeout");
+
+var TimeoutError = timeout.TimeoutError;
+// Maybe use this to check `instanceof`.
 ```
 
-#### beforeRun
 
-Called immediately before the **Zone.prototype.run** function is called.
+
+
+####### <code>Error</code>
+
+- __timeout__ <code>{Number}</code>:
+  Specifies the timeout that was exceeded.
+  
+
+#### <code>__can-zone/debug__ function</code>
+
+
+
+##### <code>debug(ms)</code>
+
+
+Creates a new [ZoneSpec](#zonespec-object) that can be provided to your Zone, timing out in `ms` (milliseconds).
 
 ```js
+var Zone = require("can-zone");
+var debug = require("can-zone/debug");
+
 var zone = new Zone({
-	beforeRun: function(){
-		// Setup that needs to happen immediately before running
-		// the zone function
-	}
+	plugins: [debug(5000)]
+})
+.catch(function(err){
+	var info = zone.data.debugInfo;
 });
-
-zone.run(function() { ... });
 ```
 
-#### beforeTask
+See the [DebugInfo](#debuginfo-arrayobject) type for a list of properties 
 
-Called before each Task is called. Use this to override any globals you want to exist during the execution of the task:
+
+1. __ms__ <code>{Number}</code>:
+  The timeout, in milliseconds, before the [Zone](#new-zone) will be rejected and debug information attached to the [zone's data](#zonedata) object.
+  
+
+##### <code>debug(timeoutZone)</code>
+
+
+Like the previous signature, but directly pass it a [timeout ZoneSpec](#timeoutms) object that you create yourself.
 
 ```js
-new Zone({
-	beforeTask: function(){
-		window.setTimeout = mySpecialSetTimeout;
-	}
-});
+var debug = require("can-zone/debug");
+var timeout = require("can-zone/timeout");
+
+var timeoutZone = timeout(5000);
+var debugZone = debug(timeoutZone):
+
+...
 ```
 
-#### afterTask
 
-Called after each Task is complete. Use this to restore state that was replaced in **beforTask**:
+1. __timeoutZone__ <code>{[can-zone/timeout](#timeoutms)}</code>:
+  A [ZoneSpec](#zonespec-object) created using the timeout plugin.
+  
+###### DebugInfo `{Array\<Object\>}`
+
+An array of objects containing information useful for debugging. Gives you the name of the **task** that failed to complete and a **stack** trace of where the error occured. 
+Each object has a shape of:
 
 ```js
-var oldSetTimeout;
-
-new Zone({
-	beforeTask: function(){
-		oldSetTimeout = window.setTimeout;
-		window.setTimeout = mySpecialSetTimeout;
-	},
-	afterTask: function(){
-		window.setTimeout = oldSetTimeout;
-	}
-});
+{
+	"task": "setTimeout",
+	"stack": Error ...."
+}
 ```
 
 
-#### ended
 
-Called when the Zone has ended and is about to exit (it's Promise will resolve).
 
-#### hooks
+####### <code>Array\<Object\></code>
 
-**hooks** allows you to specify custom hooks that your plugin calls. This is mostly to communicate between plugins that inherit each other.
-
-```js
-var barZone = {
-	created: function(){
-		this.execHook("beforeBar");
-	},
-
-	hooks: ["beforeBar"]
-};
-
-var fooZone = {
-	beforeBar: function(){
-		// Called!
-	},
-	plugins: [barZone]
-};
-
-new Zone({
-	plugins: [fooZone]
-});
-
-zone.run(function() { ... });
-```
-
-### Zones
-
-**can-zone** comes with the following Zone plugins:
-
-#### xhr
-
-Allows you to instrument XHR.
-
-#### [timeout](https://github.com/canjs/can-zone/blob/master/docs/zones/timeout.md)
-
-#### [debug](https://github.com/canjs/can-zone/blob/master/docs/zones/debug.md)
-
-Allows you to specify a timeout for the Zone, to prevent waiting indefinitely.
+- __task__ <code>{String}</code>:
+  An identifier of the task that failed to complete. This can be any of the [asynchronous tasks](https://github.com/canjs/can-zone#tasks) supported by can-zone like `setTimeout` or `Promise`.
+  
+  
+- __stack__ <code>{String}</code>:
+  A stack trace taken as a snapshot when the task was called. This allows you t see the source of the call to help debug why the task never completed.
+  
 
 ## License
 

--- a/docs/ZoneSpec.md
+++ b/docs/ZoneSpec.md
@@ -1,0 +1,103 @@
+@typedef {{}} can-zone.ZoneSpec ZoneSpec
+@parent can-zone.types
+
+@description
+A ZoneSpec is the way you tap into the lifecycle hooks of a [can-zone Zone]. The hooks are described below.
+
+Using these hooks you can do things like create timers and override global variables that will change the *shape* of code that runs within the Zone.
+
+	@option {function} created
+
+	Called when the zone is first created, after all ZoneSpecs have been parsed. this is useful if you need to do setup behavior that covers the entire zone lifecycle.
+
+	```js
+	new Zone({
+		created: function(){
+			// Called as soon as `new Zone` is called
+		}
+	});
+	```
+
+	@option {function} beforeRun
+
+	Called immediately before the **Zone.prototype.run** function is called.
+
+	```js
+	var zone = new Zone({
+		beforeRun: function(){
+			// Setup that needs to happen immediately before running
+			// the zone function
+		}
+	});
+
+	zone.run(function() { ... });
+	```
+
+	@option {function()} beforeTask
+
+	Called before each Task is called. Use this to override any globals you want to exist during the execution of the task:
+
+	```js
+	new Zone({
+		beforeTask: function(){
+			window.setTimeout = mySpecialSetTimeout;
+		}
+	});
+	```
+
+	@option {function} ended
+
+	Called when the Zone has ended and is about to exit (it's Promise will resolve).
+
+	@option {Array<string>} hooks
+
+	**hooks** allows you to specify custom hooks that your plugin calls. This is mostly to communicate between plugins that inherit each other.
+
+	```js
+	var barZone = {
+		created: function(){
+			this.execHook("beforeBar");
+		},
+
+		hooks: ["beforeBar"]
+	};
+
+	var fooZone = {
+		beforeBar: function(){
+			// Called!
+		},
+		plugins: [barZone]
+	};
+
+	new Zone({
+		plugins: [fooZone]
+	});
+
+	zone.run(function() { ... });
+	```
+
+	@option {Array<can-zone.ZoneSpec|can-zone.makeZoneSpec>} plugins
+
+	Allows specifying nested [can-zone.ZoneSpec ZoneSpecs] that the current depends on. This allows creating rich plugins that depend on other plugins (ZoneSpecs). You can imagine having a bunch of tiny plugins that do one thing and then composing them together into one meta-plugin that is more end-user friendly.
+
+	Similar to the [can-zone Zone] constructor you can either specify [can-zone.ZoneSpec] objects or functions that return ZoneSpec objects. The former gives you a closure specific to the Zone, which is often needed for variables. These two forms are equivalent:
+
+	```js
+	var specOne = {
+		created: function(){
+
+		}
+	};
+
+	var specTwo = function(){
+		return {
+			created: function(){
+
+			}
+		}
+	};
+
+	var zone = new Zone({
+		plugins: [ specOne, specTwo ]
+	});
+	```

--- a/docs/addWait.md
+++ b/docs/addWait.md
@@ -1,0 +1,21 @@
+@function can-zone.prototype.addWait addWait
+@parent can-zone.prototype
+
+@signature `zone.addWait()`
+
+Adds a wait to the [can-zone Zone]. Adding a wait will delay the Zone's Promise from resolving (the promise created by calling [can-zone.prototype.run zone.run]) by incrementing its internal counter.
+
+Usually a corresponding [can-zone.prototype.removeWait] will be called to decrement the counter.
+
+```js
+new Zone().run(function(){
+
+	var zone = Zone.current;
+
+	zone.addWait(); // counter at 1
+	zone.removeWait(); // counter at 0, Promise resolves
+
+}).then(function(){
+
+});
+```

--- a/docs/apis.json
+++ b/docs/apis.json
@@ -1,0 +1,31 @@
+[
+	{"can-zone": [
+		{"static": [
+			"can-zone.waitFor",
+			"can-zone.current",
+			"can-zone.ignore",
+			"can-zone.error"
+		]},
+		{"prototype": [
+			"can-zone.prototype.run",
+			"can-zone.prototype.data",
+			"can-zone.prototype.addWait",
+			"can-zone.prototype.removeWait"
+		]},
+		{"types": [
+			"can-zone.ZoneSpec",
+			"can-zone.makeZoneSpec"
+		]},
+		{"modules": [
+			"can-zone/register"
+		]},
+		{"plugins": [
+			{"can-zone/timeout": [
+				"can-zone/timeout.TimeoutError"
+			]},
+			{"can-zone/debug": [
+				"can-zone/debug.DebugInfo"
+			]}
+		]}
+	]}
+]

--- a/docs/can-zone.md
+++ b/docs/can-zone.md
@@ -1,0 +1,99 @@
+@module {function} can-zone
+@parent can-ecosystem
+@group can-zone.static static
+@group can-zone.prototype prototype
+@group can-zone.types types
+@group can-zone.modules modules
+@group can-zone.plugins plugins
+
+@signature `new Zone()`
+
+Creates a new Zone with no additional overrides. Can then call [can-zone.prototype.run zone.run] to call a function within the Zone.
+
+```js
+var Zone = require("can-zone");
+
+var zone = new Zone();
+
+zone.run(function(){
+
+	return "hello world";
+
+}).then(function(data){
+	data.result // -> "hello world"
+});
+```
+
+@signature `new Zone(zoneSpec)`
+
+Create a new Zone using the provided [can-zone.ZoneSpec] to configure the Zone. The following examples configures a Zone that will time out after 5 seconds.
+
+```js
+var Zone = require("can-zone");
+
+var timeoutSpec = function(){
+	var timeoutId;
+
+	return {
+		created: function(){
+			timeoutId = setTimeout(function(){
+				Zone.error(new Error("This took too long!"));
+			}, 5000);
+		},
+		ended: function(){
+			clearTimeout(timeoutId);
+		}
+	};
+};
+
+var zone = new Zone(timeoutSpec);
+```
+
+@param {can-zone.ZoneSpec|can-zone.makeZoneSpec} zoneSpec A [can-zone.ZoneSpec] object or a [can-zone.makeZoneSpec function that returns] a ZoneSpec object.
+
+These two are equivalent:
+
+```js
+new Zone({
+	created: function(){
+		
+	}
+});
+
+new Zone(function(){
+	return {
+		created: function(){
+
+		}
+	};
+});
+```
+
+The latter form is useful so that you have a closure specific to that [can-zone Zone].
+
+@body
+
+## Use
+
+**can-zone** is a library that aids in tracking asynchronous calls in your application. To create a new Zone call it's constructor function with `new`:
+
+```js
+var zone = new Zone();
+```
+
+This gives you a [can-zone Zone] from which you can run code using [can-zone.prototype.run zone.run]:
+
+```js
+zone.run(function(){
+	
+	setTimeout(function(){
+
+	}, 500);
+
+})
+then(function(){
+
+});
+```
+
+The function you provide to [can-zone.prototype.run] will be run within the Zone. This means any calls to asynchronous functions (in this example `setTimeout`)	will be waited on.

--- a/docs/current.md
+++ b/docs/current.md
@@ -1,0 +1,18 @@
+@property {can-zone} can-zone.current current
+@parent can-zone.static
+
+@signature `Zone.current`
+
+Represents the currently running [can-zone zone]. If the code using **Zone.current** is not running within a zone the value will be undefined.
+
+```js
+var Zone = require("can-zone");
+
+var myZone = new Zone();
+
+myZone.run(function(){
+
+	Zone.current === myZone;
+
+});
+```

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,0 +1,19 @@
+@property {{}} can-zone.prototype.data data
+@parent can-zone.prototype
+
+@signature `zone.data`
+
+You might want to get data back from can-zone, for example if you are using the library to track asynchronous rendering requests. Each zone contains a **data** object which can be used to store artibitrary values.
+
+```js
+var Zone = require("can-zone");
+
+var xhr = new XMLHttpRequest();
+xhr.open("GET", "http://example.com");
+xhr.onload = function(){
+	// Save this data for later
+	Zone.current.data.xhr = xhr.responseText;
+};
+xhr.send();
+```
+

--- a/docs/error.md
+++ b/docs/error.md
@@ -1,0 +1,22 @@
+@function can-zone.error error
+@parent can-zone.static
+
+@signature `Zone.error(err)`
+
+Allows you to add an error to the currently running zone.
+
+```js
+var Zone = require("can-zone");
+
+new Zone().run(function(){
+
+	setTimeout(function(){
+		Zone.error(new Error("oh no"));
+	}, 100);
+
+}).then(null, function(error){
+	error; // -> {message: "oh no"}
+});
+```
+
+@param {Error} err

--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -1,0 +1,45 @@
+@function can-zone.ignore ignore
+@parent can-zone.static
+
+@signature `Zone.ignore(fn)`
+
+Creates a function that, when called, will not track any calls. This might be needed if you are calling code that does unusual things, like using setTimeout recursively indefinitely.
+
+```js
+var Zone = require("can-zone");
+
+new Zone().run(function(){
+	function recursive(){
+		setTimeout(function(){
+			recursive();
+		}, 20000);
+	}
+
+	var fn = Zone.ignore(recursive);
+
+	// This call will not be waited on.
+	fn();
+});
+```
+
+@param {function} fn A function that contains calls to asynchronous functions that are needing to be ignored.
+
+@return {function} A function in which calls to [can-zone.prototype.addWait] and [can-zone.prototype.removeWait] will be ignored, preventing the Zone's promise from remaining unresolved while asynchronous activity continues within.
+
+@body
+
+## Use
+
+**Zone.ignore** is used to prevent a function from being waited on within a Zone. Normally a Zone's calls to functions like `setTimeout` and `XMLHttpRequest` are waited on before the [can-zone.prototype.run run promise] is resolved, but in some cases you might not want to wait on these calls; for example if there is a very long delay or a delay that will not result in rendering to take place.
+
+Provide Zone.ignore a function and it will return a function that can be called in it's place.
+
+```js
+var Zone = require("can-zone");
+
+var fn = Zone.ignore(function(){
+	// do any asynchronous stuff here
+});
+
+fn(); // waits ignored
+```

--- a/docs/makeZoneSpec.md
+++ b/docs/makeZoneSpec.md
@@ -1,0 +1,44 @@
+@typedef {function():can-zone.ZoneSpec} can-zone.makeZoneSpec makeZoneSpec
+@parent can-zone.types
+
+A function that returns a [can-zone.ZoneSpec] object. This can be used any place where a [can-zone.ZoneSpec] is accepted.
+
+Using a function rather than a ZoneSpec object gives you a closure where you can store local variables that will be specific to the [can-zone Zone] you are running in.
+
+@param {can-zone.prototype.data} data The [can-zone Zone's] data object, useful when you want to append data to the Zone.
+
+This examples wraps [document.createElement](https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement) to keep count of how many elements are created, and appends the count to [can-zone.prototype.data] when the Zone ends.
+
+```js
+var mySpec = function(data){
+	var realCreateElement,
+		count = 0;
+
+	return {
+		beforeTask: function(){
+			realCreateElement = document.createElement;
+			document.createElement = function(){
+				count++;
+				return realCreateElement.apply(this, arguments);
+			};
+		},
+		afterTask: function(){
+			document.createElement = realCreateElement;
+		},
+		ended: function(){
+			data.elementsCreated = count;
+		}
+	};
+};
+
+var zone = new Zone(mySpec);
+
+zone.run(function(){
+	// Do stuff here
+})
+.then(function(data){
+	data.elementsCreated; // -> 5
+});
+```
+
+@return {can-zone.ZoneSpec} A [can-zone.ZoneSpec]

--- a/docs/register.md
+++ b/docs/register.md
@@ -1,6 +1,9 @@
-## can-zone/register
+@module {function} can-zone/register can-zone/register
+@parent can-zone.modules
 
-In order to do it's magic, can-zone has to register handlers for all of the common JavaScript async operations. If you have code (or a dependency with this code) that does:
+@description
+
+In order to do it's magic, [can-zone] has to register handlers for all of the common JavaScript async operations. If you have code (or a dependency with this code) that does:
 
 ```js
 var st = setTimeout;

--- a/docs/removeWait.md
+++ b/docs/removeWait.md
@@ -1,0 +1,23 @@
+@function can-zone.prototype.removeWait removeWait
+@parent can-zone.prototype
+
+@signature `zone.removeWait()`
+
+Decrements the [can-zone Zone's] internal counter that is used to decide when its [can-zone.prototype.run run Promise] will resolve.
+
+Usually used in conjuction with [can-zone.prototype.addWait]. Most of the time you'll want to use [can-zone.waitFor], but in some cases where a callback is not enough to know waiting is complete, using addWait/removeWait gives you finer grained control.
+
+```js
+var zone = new Zone();
+
+var obj = new SomeObject();
+
+// This is only done when the event.status is 3
+obj.onprogress = function(ev){
+	if(ev.status === 3) {
+		zone.removeWait();
+	}
+};
+
+zone.addWait();
+```

--- a/docs/run.md
+++ b/docs/run.md
@@ -1,0 +1,24 @@
+@function can-zone.prototype.run run
+@parent can-zone.prototype
+
+@signature `zone.run(fn)`
+
+Runs a function within a [can-zone Zone]. Calling run will set the Zone's internal Promise which will only resolve once all asynchronous calls within `fn` are complete.
+
+@param {function} fn Any function which needs to run within the Zone. The function will be executed immediately.
+
+@return {Promise<can-zone.prototype.data>} Returns a promise that will resolve with the Zone's [can-zone.prototype.data] object.
+
+```js
+var zone = new Zone();
+
+zone.run(function(){
+
+	setTimeout(function(){
+		zone.data.foo = "bar";
+	});
+
+}).then(function(data){
+	data.foo // -> "bar"
+});
+```

--- a/docs/waitFor.md
+++ b/docs/waitFor.md
@@ -1,0 +1,19 @@
+@function can-zone.waitFor waitFor
+@parent can-zone.static
+
+@signature `Zone.waitFor(fn)`
+
+**Zone.waitFor** is a function that creates a callback that can be used with any async functionality. Calling Zone.waitFor registers a wait with the currently running request and returns a function that, when called, will decrement the wait count.
+
+This is useful if there is async functionality other than what [we implement](#tasks). You might be using a library that has C++ bindings and doesn't go through the normal JavaScript async APIs.
+
+```js
+var Zone = require("can-zone");
+var fs = require("fs");
+
+fs.readFile("data.json", "utf8", Zone.waitFor(function(){
+	// We waited on this!
+}));
+```
+
+@param {function} fn

--- a/docs/zones/debug.md
+++ b/docs/zones/debug.md
@@ -1,4 +1,45 @@
-# can-zone/debug
+@module {function} can-zone/debug can-zone/debug
+@parent can-zone.plugins
+
+@signature `debug(ms)`
+
+Creates a new [can-zone.ZoneSpec] that can be provided to your Zone, timing out in `ms` (milliseconds).
+
+```js
+var Zone = require("can-zone");
+var debug = require("can-zone/debug");
+
+var zone = new Zone({
+	plugins: [debug(5000)]
+})
+.catch(function(err){
+	var info = zone.data.debugInfo;
+});
+```
+
+See the [can-zone/debug.DebugInfo] type for a list of properties 
+
+@param {Number} ms The timeout, in milliseconds, before the [can-zone Zone] will be rejected and debug information attached to the [can-zone.prototype.data zone's data] object.
+
+@signature `debug(timeoutZone)`
+
+Like the previous signature, but directly pass it a [can-zone/timeout timeout ZoneSpec] object that you create yourself.
+
+```js
+var debug = require("can-zone/debug");
+var timeout = require("can-zone/timeout");
+
+var timeoutZone = timeout(5000);
+var debugZone = debug(timeoutZone):
+
+...
+```
+
+@param {can-zone/timeout} timeoutZone A [can-zone.ZoneSpec] created using the timeout plugin.
+
+@body
+
+## Use
 
 The **debug** zone gives you information about which tasks failed to complete in case of a timeout. It is to be used with [./timeout.md](can-zone/timeout).
 
@@ -19,7 +60,6 @@ zone.run(function(){
 	var debugInfo = zone.data.debugInfo;
 
 });
-
 ```
 
 ## DebugInfo

--- a/docs/zones/debuginfo.md
+++ b/docs/zones/debuginfo.md
@@ -1,0 +1,18 @@
+@typedef {Array<{}>} can-zone/debug.DebugInfo DebugInfo
+@parent can-zone/debug
+
+@description An array of objects containing information useful for debugging. Gives you the name of the **task** that failed to complete and a **stack** trace of where the error occured.
+
+Each object has a shape of:
+
+```js
+{
+	"task": "setTimeout",
+	"stack": Error ...."
+}
+```
+
+@option {String} task An identifier of the task that failed to complete. This can be any of the [asynchronous tasks](https://github.com/canjs/can-zone#tasks) supported by can-zone like `setTimeout` or `Promise`.
+
+
+@option {String} stack A stack trace taken as a snapshot when the task was called. This allows you t see the source of the call to help debug why the task never completed.

--- a/docs/zones/timeout.md
+++ b/docs/zones/timeout.md
@@ -1,10 +1,43 @@
-# can-zone/timeout
+@module {function(ms)} can-zone/timeout can-zone/timeout
+@parent can-zone.plugins
+
+@signature `timeout(ms)`
+
+Creates a [can-zone.ZoneSpec] that you can use as a plugin for your [can-zone Zone] in order to timeout after a certain length of time (as `ms`).
+
+If the Zone times out it's [can-zone.prototype.run run promise] will be rejected with a [can-zone/timeout.TimeoutError], a special error that also includes the number of milliseconds waited before timing out.
+
+```js
+var Zone = require("can-zone");
+var timeout = require("can-zone/timeout");
+
+var zone = new Zone({
+	plugins: [ timeout(5000) ]
+});
+
+zone.run(function(){
+	setTimeout(function(){
+
+	}, 10000); // waiting over 5 sec
+})
+.catch(function(err){
+	// Called because we exceeded the timeout.
+});
+```
+
+@param {Number} ms The number of milliseconds to wait before timing out the [can-zone Zone].
+
+@return {can-zone.ZoneSpec} A ZoneSpec that can be passed as a plugin.
+
+@body
+
+## Use
 
 The timeout zone allows you to specify a timeout for your Zone. If the Zone promise doesn't resolve before timing out, the Zone promise will be rejected by the plugin.
 
 The **timeout** zone is a function that takes a timeout in milliseconds.
 
-The Promise will reject with a special type of Error, a **TimeoutError**.
+The Promise will reject with a special type of Error, a [can-zone/timeout.TimeoutError].
 
 ```js
 var Zone = require("can-zone");

--- a/docs/zones/timeouterror.md
+++ b/docs/zones/timeouterror.md
@@ -1,0 +1,17 @@
+@typedef {Error} can-zone/timeout.TimeoutError TimeoutError
+@parent can-zone/timeout
+
+@inherits {Error} Inherits from a normal [Error object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error).
+
+@description A special type of Error that also includes the number of milliseconds that were waited before timing out.
+
+The error object is included with the timeout module:
+
+```js
+var timeout = require("can-zone/timeout");
+
+var TimeoutError = timeout.TimeoutError;
+// Maybe use this to check `instanceof`.
+```
+
+@option {Number} timeout Specifies the timeout that was exceeded.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/zone.js",
   "scripts": {
     "build": "node scripts/build.js",
+    "document": "bit-docs",
     "test:node": "mocha test/test.js && mocha test/test_register_node.js",
     "test:browser": "testee test/test.html test/register.html --browsers firefox --reporter Spec",
     "test": "npm run test:node && npm run test:browser"
@@ -27,6 +28,7 @@
   },
   "homepage": "https://github.com/canjs/can-zone#readme",
   "devDependencies": {
+    "bit-docs": "0.0.7",
     "chai": "^3.4.1",
     "mocha": "^2.3.4",
     "steal": "^0.12.4",
@@ -49,5 +51,21 @@
         "exports": "chai.assert"
       }
     }
+  },
+  "bit-docs": {
+    "dependencies": {
+      "bit-docs-glob-finder": "^0.0.5",
+      "bit-docs-dev": "^0.0.3",
+      "bit-docs-js": "^0.0.3",
+      "bit-docs-generate-readme": "^0.0.8"
+    },
+    "glob": {
+      "pattern": "**/*.{js,md}",
+      "ignore": "node_modules/**/*"
+    },
+    "readme": {
+      "apis": "./docs/apis.json"
+    },
+    "parent": "can-view-live"
   }
 }


### PR DESCRIPTION
This updates our API docs to use bit-docs so that we can have finer
grained documentation for each function, property, and type within
can-zone.