### PR TITLE
Fixing setTimeout so it passes extra parameters through to the callback function

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -39,16 +39,17 @@ var removeTimer = function(timeoutId, callback){
 
 exports.setTimeout = function(setTimeout){
 	return function(fn, timeout){
+		var args = Array.prototype.slice.call(arguments);
 		var zone = Zone.current;
 		var idInfo;
-		var callback = zone.waitFor(function(){
+		args[0] = zone.waitFor(function(){
 			delete zone.ids[idInfo.id];
 			return fn.apply(this, arguments);
 		});
 
 		var self = this;
 		idInfo = addTimer(function(){
-			return setTimeout.call(self, callback, timeout);
+			return setTimeout.apply(self, args);
 		});
 
 		return idInfo.timeoutId;

--- a/test/test.js
+++ b/test/test.js
@@ -252,6 +252,17 @@ describe("setTimeout", function(){
 		});
 	});
 
+	it("Passes extra parameters to callback", function(done){
+		var zone = new Zone();
+		zone.run(function(){
+			setTimeout(function(str1, str2){
+				zone.data.foo = str1 + "-" + str2;
+			}, 10, "can", "zone");
+		}).then(function(data){
+			assert.equal(data.foo, "can-zone", "Extra parameters are passed");
+		}).then(done, done);
+	});
+
 	it("Can be in nested Zones", function(done){
 		var zoneOne = new Zone();
 		zoneOne.run(function(){


### PR DESCRIPTION
can-zone's setTimeout only passes the callback and delay to `window.setTimeout` [here](https://github.com/canjs/can-zone/compare/pass-extra-params-to-settimeout?expand=1#diff-17a298a4fcdf2c8fee67743145edf5f1L51).

[`setTimeout`](https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/setTimeout) can be passed parameters that should be passed through to the callback. 

This PR makes sure all arguments are passed to setTimeout; making sure the first argument is the `waitsFor` function can-zone creates.

**Example**
```js
var Zone = require("can-zone");

var zone = new Zone();

zone.run(function(){

  setTimeout(function(str1, str2){
		zone.data.foo = str1 + "-" + str2; //-> undefined-undefined
	}, 100, "can-zone", "canjs")

}).then(function(data){
  console.log(data.foo);
});
```

