### PR TITLE
Reset zone.runningTask after running a task

### DIFF
--- a/lib/zone.js
+++ b/lib/zone.js
@@ -47,10 +47,11 @@ Task.prototype.run = function(ctx, args){
 		} else {
 			throw err;
 		}
+	} finally {
+		// If this is a nested task (a task run synchronously then this will
+		// remain as true
+		zone.runningTask = this.nestedTask;
 	}
-	// If this is a nested task (a task run synchronously then this will
-	// remain as true
-	zone.runningTask = this.nestedTask;
 
 	return res;
 };

--- a/test/test.js
+++ b/test/test.js
@@ -565,7 +565,8 @@ describe("Promises", function(){
 
 	it("Throwing in a Promise chain is returned", function(done){
 		var caught;
-		new Zone().run(function(){
+		var zone = new Zone();
+		zone.run(function(){
 			Promise.resolve().then(function(){
 				throw new Error("oh no");
 			}).then(null, function(err){
@@ -576,6 +577,7 @@ describe("Promises", function(){
 					 "resolved wait promise");
 			assert(!!caught, "Called the Promise errback");
 			assert.equal(caught.message, "oh no", "Correct error object");
+			assert(!zone.runningTask, "Zone is not currently running a task");
 		}).then(done);
 	});
 


### PR DESCRIPTION
When a task run, whether there was an error or not, we should be
resetting the `runningTask` variable. This is used to control that hooks
are not called multiple times.