### PR TITLE
Don't rethrow in a Promise rejection

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -106,8 +106,7 @@ exports.then = function(then){
 			if(fn) {
 				return fn.apply(this, arguments);
 			} else if(rejected) {
-				val = typeof val === "string" ? new Error(val) : val;
-				throw val;
+				return Promise.reject(val);
 			}
 			return val;
 		}, false);

--- a/test/test.js
+++ b/test/test.js
@@ -597,7 +597,7 @@ describe("Promises", function(){
 		new Zone().run(function(){
 
 			Promise.reject("uh oh").then().then(null, function(err){
-				Zone.current.data.reason = err.message;
+				Zone.current.data.reason = err;
 			});
 
 		}).then(function(data){


### PR DESCRIPTION
Instead of rethrowing in a promise rejection, which forces the rejection
into an Error object, simply return a new Promise.reject(val).

Closes #92