### PR TITLE
Make event handlers run within a Zone

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -185,3 +185,10 @@ exports.MutationObserver = function(MutationObserver){
 		return new MutationObserver(fn);
 	};
 };
+
+exports.addEventListener = function(addEventListener){
+	return function(eventName, handler, useCapture){
+		handler = CanZone.current.wrap(handler);
+		return addEventListener.call(this, eventName, handler, useCapture);
+	};
+};

--- a/register.js
+++ b/register.js
@@ -29,6 +29,7 @@
 		"requestAnimationFrame",
 		"Promise.prototype.then",
 		"XMLHttpRequest.prototype.send",
+		"Node.prototype.addEventListener",
 		"process.nextTick",
 		"setImmediate",
 		"clearImmediate",

--- a/test/test.js
+++ b/test/test.js
@@ -748,6 +748,30 @@ if(supportsMutationObservers) {
 	});
 }
 
+if(isBrowser) {
+	describe("addEventListener", function(){
+		it("is run within a zone", function(done){
+			this.timeout(2000);
+
+			var el = document.createElement("div");
+
+			new Zone().run(function(){
+				var id = setTimeout(function(){}, 10000);
+
+				el.addEventListener("clear-me", function(){
+					assert.ok(Zone.current, "this is run in a zone");
+					clearTimeout(id);
+				});
+			}).then(function(){
+				assert.ok(true, "it finished");
+			})
+			.then(done, done);
+
+			el.dispatchEvent(new Event("clear-me"));
+		});
+	});
+}
+
 if(isNode) {
 	describe("process.nextTick", function(){
 		it("works", function(done){


### PR DESCRIPTION
This ensures that event handlers are run within a zone. This fixes the
case where you could set up a timer within a Zone and clear it in an
event handler; if the event handler is not within the Zone it will not
decrement the Zone counter.

Fixes #104