### PR TITLE
Store timeout ids correctly when they are a number

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -8,7 +8,7 @@ if(env.isNode) {
 var addTimer = function(callback){
 	var timeoutId = callback();
 	var id = timeoutId;
-	if(env.isNode) {
+	if(env.isNode && typeof id !== "number") {
 		id = timeoutId.__timeoutId = globalTimeoutId++;
 	}
 	var zone = CanZone.current;
@@ -29,7 +29,8 @@ var removeTimer = function(timeoutId, callback){
 	}
 	var zone = CanZone.current;
 	var ids = zone.ids;
-	var id = env.isNode ? timeoutId.__timeoutId : timeoutId;
+	var id = (env.isNode && typeof timeoutId !== "number") ?
+		timeoutId.__timeoutId : timeoutId;
 	if(!zone.isResolved && ids[id]) {
 		delete ids[id];
 		zone.removeWait();

--- a/test/test.js
+++ b/test/test.js
@@ -342,6 +342,21 @@ describe("setTimeout", function(){
 				assert.ok(true, "it finished");
 			}).then(done);
 		});
+
+		if(!isNode) {
+			it("Decrements the wait count when in a Node-like environment with number timeout ids", function(done){
+				// This is to fake NW.js
+				env.isNode = true;
+				new Zone().run(function(){
+					var id = setTimeout(Function.constructor, 20000);
+					clearTimeout(id);
+				}).then(function(){
+					env.isNode = false;
+					assert.ok(true, "it finished");
+				})
+				.then(done);
+			});
+		}
 	});
 });
 
@@ -789,7 +804,6 @@ if(isNode) {
 	describe("setImmediate", function(){
 		it("works", function(done){
 			new Zone().run(function(){
-				debugger;
 				setImmediate(function(){
 					Zone.current.data.hello = "world";
 				});


### PR DESCRIPTION
In Node there is a timeout id that looks like this: `{ ... }`

However in NW.js it is a number like in the browser. So when special
casing for the Node kinda ids, take into account that it might be a
number and use a number where you can.

Closes #106