### PR TITLE
Use POST body for filtering requests in XHR_CACHE

### DIFF
--- a/lib/zones/xhr.js
+++ b/lib/zones/xhr.js
@@ -8,6 +8,11 @@ var WAIT_URL = util.symbol("__canWaitURL");
 function browserZone(data){
 	var cache, oldOpen, oldSend;
 
+	var matches = function(request, url, body) {
+		return (request.url === url) &&
+			(!body || request.data === body);
+	};
+
 	var open = function(method, url){
 		util.defineProperty(this, WAIT_URL, {
 			value: url,
@@ -16,12 +21,12 @@ function browserZone(data){
 		return oldOpen.apply(this, arguments);
 	};
 
-	var send = function(){
+	var send = function(body){
 		var data, response;
 		var url = this[WAIT_URL];
 		for(var i = 0, len = cache.length; i < len; i++) {
 			data = cache[i];
-			if(data.request.url === url) {
+			if(matches(data.request, url, body)) {
 				response = setResponse(this, data.response);
 				cache.splice(i, 1);
 				break;
@@ -70,7 +75,7 @@ function nodeZone(data){
 		return oldOpen.apply(this, arguments);
 	};
 
-	var send = function(){
+	var send = function(body){
 		var onload = this.onload,
 			thisXhr = this;
 
@@ -83,7 +88,8 @@ function nodeZone(data){
 			}
 			data.xhr.data.push({
 				request: {
-					url: xhr[WAIT_URL]
+					url: xhr[WAIT_URL],
+					data: body
 				},
 				response: {
 					status: xhr.status,


### PR DESCRIPTION
This makes it so that request bodies are saved during server-side caching, and then used to match an XHR request back in the client.

Closes #112