### PR TITLE
Ensure that ended is only called once.

### DIFF
--- a/lib/zone.js
+++ b/lib/zone.js
@@ -249,7 +249,9 @@ Zone.prototype.wrap = function(fn, catchErrors){
 };
 
 Zone.prototype.end = function(){
-	this.execHook("ended");
+	if(!this.isResolved) {
+		this.execHook("ended");
+	}
 	var dfd = this.deferred;
 	if(this.errors.length) {
 		var error = this.errors[0];

--- a/test/test.js
+++ b/test/test.js
@@ -209,6 +209,23 @@ describe("new Zone", function(){
 			done();
 		});
 	});
+
+	it("the ended hook is only called once", function(done){
+		var count = 0;
+		new Zone({
+			ended: function() { count++; }
+		}).run(function(){
+			setTimeout(function(){}, 0);
+
+			throw new Error("some error");
+		})
+		.catch(function(){
+			setTimeout(function(){
+				assert.equal(count, 1, "Endeded called once");
+				done();
+			}, 10);
+		});
+	});
 });
 
 describe("Reusing zones", function(){


### PR DESCRIPTION
In case waits are added and removed after the Zone's run promise is
complete, never call the "ended" hook again. Fixes #118