### PR TITLE
Adds an afterRun hook

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,6 @@ test_script:
   # Output useful info for debugging.
   - node --version
   - npm --version
-  - set DEBUG=*
   # run tests
   - npm test
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ test_script:
   - node --version
   - npm --version
   # run tests
+  - npm run test:node
   - npm run test:win
 
 # Don't actually build.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ test_script:
   - node --version
   - npm --version
   # run tests
-  - npm test
+  - npm run test:win
 
 # Don't actually build.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ test_script:
   # Output useful info for debugging.
   - node --version
   - npm --version
+  - set DEBUG=*
   # run tests
   - npm test
 

--- a/docs/ZoneSpec.md
+++ b/docs/ZoneSpec.md
@@ -20,7 +20,7 @@ Using these hooks you can do things like create timers and override global varia
 
 	@option {function} beforeRun
 
-	Called immediately before the **Zone.prototype.run** function is called.
+	Called immediately before the [can-zone.prototype.run] function is called.
 
 	```js
 	var zone = new Zone({
@@ -31,6 +31,30 @@ Using these hooks you can do things like create timers and override global varia
 	});
 
 	zone.run(function() { ... });
+	```
+
+	@option {function} afterRun
+
+	Called immediately after the [can-zone.prototype.run] function is called. This hook is useful for any cleanup that might need to be done after the run function is called, but before the zone's promise is resolved. You might use this if the promise is not waited on before performing some action.
+
+	```js
+	require("http").createServer(function(req, res){
+		var zone = new Zone(function(data){
+			var document = new SomeDocument();
+
+			return {
+				...
+				afterRun: function(){
+					data.html = document.documentElement.outerHTML;
+				}
+			};
+		});
+
+		zone.run(render); // We don't want to wait for all async stuff.
+
+		res.write(zone.data.html);
+		res.end();
+	}).listen(8080);
 	```
 
 	@option {function()} beforeTask

--- a/lib/zone.js
+++ b/lib/zone.js
@@ -61,7 +61,8 @@ var hooks = [
 	"afterTask",
 	"created",
 	"ended",
-	"beforeRun"
+	"beforeRun",
+	"afterRun"
 ];
 
 var commonGlobals = [
@@ -195,6 +196,10 @@ Zone.prototype.run = function(fn){
 
 	// Call the function
 	this.data.result = task.run();
+
+	if(!this.isResolved) {
+		this.execHook("afterRun");
+	}
 
 	// If we are already done
 	if(!this.waits || this.errors.length) {

--- a/package.json
+++ b/package.json
@@ -8,12 +8,8 @@
     "build": "node scripts/build.js",
     "document": "bit-docs",
     "test:node": "mocha test/test.js && mocha test/test_register_node.js",
-<<<<<<< HEAD
-    "test:browser": "DEBUG=testee:* testee test/test.html test/register.html --browsers firefox --reporter Spec",
-=======
     "test:browser": "testee test/test.html test/register.html --browsers firefox --reporter Spec",
-	"test:win": "testee test/test.html test/register.html --browsers firefox --reporter Spec",
->>>>>>> Make a test:win
+	"test:win": "testee test/test.html --browsers firefox --reporter Spec",
     "test:xss": "mocha test/xss/test.js",
     "test": "npm run test:node && npm run test:browser && npm run test:xss",
     "version": "git commit -am \"Update dist for release\" && git checkout -b release && git add -f dist/",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "steal": "^1.2.10",
     "steal-mocha": "^1.0.0",
     "steal-tools": "^1.1.2",
-    "testee": "^0.3.1"
+    "testee": "^0.7.0"
   },
   "steal": {
     "npmDependencies": [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,12 @@
     "build": "node scripts/build.js",
     "document": "bit-docs",
     "test:node": "mocha test/test.js && mocha test/test_register_node.js",
+<<<<<<< HEAD
     "test:browser": "DEBUG=testee:* testee test/test.html test/register.html --browsers firefox --reporter Spec",
+=======
+    "test:browser": "testee test/test.html test/register.html --browsers firefox --reporter Spec",
+	"test:win": "testee test/test.html test/register.html --browsers firefox --reporter Spec",
+>>>>>>> Make a test:win
     "test:xss": "mocha test/xss/test.js",
     "test": "npm run test:node && npm run test:browser && npm run test:xss",
     "version": "git commit -am \"Update dist for release\" && git checkout -b release && git add -f dist/",

--- a/test/test.js
+++ b/test/test.js
@@ -83,6 +83,24 @@ describe("new Zone", function(){
 		}).then(done);
 	});
 
+	it("Provides beforeRun and afterRun hooks", function(done){
+		var zone = new Zone(function(data){
+			return {
+				beforeRun: function(){
+					data.beforeRunCalled = true;
+				},
+				afterRun: function(){
+					data.afterRunCalled = true;
+				}
+			};
+		});
+
+		zone.run(function(){}).then(function(data){
+			assert.ok(data.beforeRunCalled, "beforeRun did get called.");
+			assert.ok(data.afterRunCalled, "afterRun did get called.");
+		}).then(done, done);
+	});
+
 	if(isNode) {
 		it("Allows you to put common globals directly on spec object",
 		   function(done){


### PR DESCRIPTION
This PR adds an `afterRun` hook that is used to run code within plugins
after the `run` function has been called. This is useful if the user of
a Zone isn't going to wait on the run promise to resolve before doing
something.