### PR TITLE
Allow passing only an array as the ZoneSpec

### DIFF
--- a/lib/zone.js
+++ b/lib/zone.js
@@ -86,6 +86,8 @@ function buildZoneSpec(zone, spec, plugins, processedSpecs){
 	plugins = plugins || [];
 	if(typeof spec === "function") {
 		spec = spec(zone.data);
+	} else if(Array.isArray(spec)) {
+		spec = { plugins: spec };
 	}
 
 	// Depth-first, call all of the plugins.

--- a/test/test.js
+++ b/test/test.js
@@ -83,6 +83,19 @@ describe("new Zone", function(){
 		}).then(done);
 	});
 
+	it("Can pass plugins if using an Array as the Zone argument", function(done){
+		var endZone = {
+			ended: function(){
+				this.data.hasEnded = true;
+			}
+		};
+
+		new Zone([endZone]).run(function(){}).then(function(data){
+			assert.ok(data.hasEnded, "This zone was used");
+		})
+		.then(done, done);
+	});
+
 	it("Provides beforeRun and afterRun hooks", function(done){
 		var zone = new Zone(function(data){
 			return {


### PR DESCRIPTION
This makes an Array a valid ZoneSpec. This is useful in the case where
you are only using plugins and not writing any of your own (which is
		common), so that you can write like so:

```js
new Zone([
  plugin(),

  another(arg)
]);
```

Closes #133