### PR TITLE
Implement removeEventListener

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -1,4 +1,5 @@
 var env = require("./env");
+var util = require("./util");
 var slice = Array.prototype.slice;
 
 if(env.isNode) {
@@ -187,9 +188,19 @@ exports.MutationObserver = function(MutationObserver){
 	};
 };
 
+var EVENT_HANDLER = util.symbol("zone-eventhandler");
+
 exports.addEventListener = function(addEventListener){
 	return function(eventName, handler, useCapture){
-		handler = CanZone.current.wrap(handler);
-		return addEventListener.call(this, eventName, handler, useCapture);
+		var outHandler = CanZone.current.wrap(handler);
+		handler[EVENT_HANDLER] = outHandler;
+		return addEventListener.call(this, eventName, outHandler, useCapture);
+	};
+};
+
+exports.removeEventListener = function(removeEventListener){
+	return function(eventName, handler, useCapture){
+		var outHandler = handler[EVENT_HANDLER] || handler;
+		return removeEventListener.call(this, eventName, outHandler, useCapture);
 	};
 };

--- a/register.js
+++ b/register.js
@@ -30,6 +30,7 @@
 		"Promise.prototype.then",
 		"XMLHttpRequest.prototype.send",
 		"Node.prototype.addEventListener",
+		"Node.prototype.removeEventListener",
 		"process.nextTick",
 		"setImmediate",
 		"clearImmediate",

--- a/test/test.js
+++ b/test/test.js
@@ -832,6 +832,24 @@ if(isBrowser) {
 
 			el.dispatchEvent(new Event("clear-me"));
 		});
+
+		it("removeEventListener removes the handler", function(done){
+			var el = document.createElement("div");
+
+			new Zone().run(function(){
+				function handler() {
+					throw new Error("This should not run");
+				}
+
+				el.addEventListener("some-test", handler);
+				el.removeEventListener("some-test", handler);
+				el.dispatchEvent(new Event("some-test"));
+			})
+			.then(function(data){
+				assert.ok(true, "it finished");
+			})
+			.then(done, done);
+		});
 	});
 }
 


### PR DESCRIPTION
This implements removeEventListener, so that handlers that are created
within a zone but later removed, will actually be unregistered. This
prevents memory leaks and other bugs.

Closes #144