### PR TITLE
Make sure wrapped event handler is created only once

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -192,8 +192,12 @@ var EVENT_HANDLER = util.symbol("zone-eventhandler");
 
 exports.addEventListener = function(addEventListener){
 	return function(eventName, handler, useCapture){
-		var outHandler = CanZone.current.wrap(handler);
-		handler[EVENT_HANDLER] = outHandler;
+		var outHandler = handler[EVENT_HANDLER];
+		if(outHandler === undefined) {
+			outHandler = CanZone.current.wrap(handler);
+			handler[EVENT_HANDLER] = outHandler;
+		}
+
 		return addEventListener.call(this, eventName, outHandler, useCapture);
 	};
 };

--- a/test/test.js
+++ b/test/test.js
@@ -842,7 +842,9 @@ if(isBrowser) {
 				}
 
 				el.addEventListener("some-test", handler);
+				el.addEventListener("another-test", handler);
 				el.removeEventListener("some-test", handler);
+				el.removeEventListener("another-test", handler);
 				el.dispatchEvent(new Event("some-test"));
 			})
 			.then(function(data){


### PR DESCRIPTION
This makes sure that we only create the zone-wrapped event handler once,
so that using the same handler in multiple events won't result in
new handlers getting created (which could lead to memory leaks if
removeEventListener is later called).

Closes #144