### PR TITLE
Implements debug zone {break: true}

### DIFF
--- a/docs/zones/debug.md
+++ b/docs/zones/debug.md
@@ -17,7 +17,7 @@ var zone = new Zone({
 });
 ```
 
-See the [can-zone/debug.DebugInfo] type for a list of properties 
+See the [can-zone/debug.DebugInfo] type for a list of properties.
 
 @param {Number} ms The timeout, in milliseconds, before the [can-zone Zone] will be rejected and debug information attached to the [can-zone.prototype.data zone's data] object.
 
@@ -37,6 +37,16 @@ var debugZone = debug(timeoutZone):
 
 @param {can-zone/timeout} timeoutZone A [can-zone.ZoneSpec] created using the timeout plugin.
 
+@signature `debug(timeoutOrTimeoutZone, options)`
+
+Creates a new [can-zone.ZoneSpec] using either a timeout in milliseconds, or a [can-zone/timeout timeout ZoneSpec], along with an *options* object. The following options are available:
+
+@param {Number|can-zone/timeout} timeoutOrTimeoutZone Either a `Number` timeout, or a [can-zone/timeout timeout ZoneSpec].
+
+@param {Object} [options] An options object with the following parameters:
+
+  * __break__ (Boolean): When enabled, causes a `debugger;` statement to be hit after the timeout is complete. This allows stepping into the code that is preventing the Zone's run promise from completing.
+
 @body
 
 ## Use
@@ -49,7 +59,7 @@ When a timeout occurs the debug Zone will appending debug information to the Zon
 var debug = require("can-zone/debug");
 var Zone = require("can-zone");
 
-var zone = new Zone(debug(5000);
+var zone = new Zone(debug(5000));
 
 zone.run(function(){
 
@@ -69,7 +79,7 @@ The **DebugInfo** is an array of objects that contain information about which ta
 ```js
 {
 	"task": "setTimeout",
-	"stack": Error ...."
+	"stack": "Error ...."
 }
 ```
 
@@ -89,11 +99,9 @@ Create a debug Zone by passing the debug function a timeout in milliseconds:
 var debug = require("can-zone/debug");
 var Zone = require("can-zone");
 
-new Zone({
-	plugins: [
-		debug(5000)
-	]
-});
+new Zone([
+	debug(5000)
+[);
 ```
 
 ## debug(timeoutZone)
@@ -108,10 +116,27 @@ var Zone = require("can-zone");
 var timeoutZone = timeout(5000);
 var debugZone = debug(timeoutZone);
 
-new Zone({
-	plugins: [
-		timeoutZone,
-		debugZone
-	]
-});
+new Zone([
+	timeoutZone,
+	debugZone
+]);
 ```
+
+## Break on timeout
+
+The default behavior of the debug zone is to store stack traces on `zone.data.debugInfo`. Some times it is easier to actually step into the code that is running. You can enable this behavior by setting the `break` option like so:
+
+```js
+var Zone = require("can-zone");
+var debug = require("can-zone/debug");
+
+var zone = new Zone([
+	debug(5000, { break: true });
+]);
+```
+
+When the zone times out you'll dropped into this breakpoint:
+
+<img alt="Break on timeout" style="max-width:100%;" src="https://user-images.githubusercontent.com/361671/32962443-6eb478d8-cb9a-11e7-9f88-f60ff5712f01.png"/>
+
+As the comment says, you can step into the proceeding function to find the code that is responsible for the zone's run promise not completing.

--- a/lib/zones/debug-break.js
+++ b/lib/zones/debug-break.js
@@ -1,0 +1,11 @@
+
+module.exports = function(fn, args) {
+	/*
+	 * Hi there! Stepping into the below function will take you to the code
+	 * that is preventing the Zone to finish. You might see some can-zone code
+	 * first, if so just keep stepping in. Best of luck!
+	**/
+
+	debugger;
+	return fn.apply(this, args);
+};

--- a/lib/zones/debug.js
+++ b/lib/zones/debug.js
@@ -1,10 +1,12 @@
 var Zone = require("../zone");
 var timeout = require("./timeout");
 var isNode = require("../env").isNode;
+var debugBreak = require("./debug-break");
 
-module.exports = function(timeoutOrTimeoutZone){
+var debugZone = function(timeoutOrTimeoutZone, options){
 	var timeoutZone;
 	var argType = typeof timeoutOrTimeoutZone;
+	var breakOnTimeout = options && options.break;
 
 	if(argType === "function") {
 		timeoutZone = timeoutOrTimeoutZone;
@@ -19,6 +21,8 @@ module.exports = function(timeoutOrTimeoutZone){
 
 		var taskFns = {};
 		var queue = [];
+		var timedOut = false, resetEnd = false;
+		var oldEnd;
 
 		return {
 			created: function(){
@@ -29,11 +33,23 @@ module.exports = function(timeoutOrTimeoutZone){
 						return function(){
 							var e = new Error();
 							var waitFor = Zone.prototype.waitFor;
-							Zone.prototype.waitFor = function(){
+							Zone.prototype.waitFor = function(providedFn){
+								if(breakOnTimeout && timedOut) {
+									var userFn = providedFn;
+									arguments[0] = function(){
+										if(debugZone._testing) {
+											return userFn.apply(this, arguments);
+										}
+
+										return debugBreak.call(this, userFn, arguments);
+									};
+								}
+
 								var waitFn = waitFor.apply(this, arguments);
 								var wrapped = function(){
 									var idx = queue.indexOf(wrapped);
 									queue.splice(idx, 1);
+
 									return waitFn.apply(this, arguments);
 								};
 								wrapped.__debugInfo = {
@@ -58,6 +74,7 @@ module.exports = function(timeoutOrTimeoutZone){
 			},
 
 			beforeTimeout: function(){
+				timedOut = true;
 				var infos = queue.map(function(fn){
 					var info = fn.__debugInfo;
 					return {
@@ -69,12 +86,31 @@ module.exports = function(timeoutOrTimeoutZone){
 				});
 				data.debugInfo = infos;
 				queue = [];
+
+				// On break, override `zone.end` so that the timeout zone
+				// Doesn't end the zone prematurely.
+				if(breakOnTimeout) {
+					oldEnd = this.end;
+					this.end = Function.prototype;
+				}
+			},
+
+			afterTask: function() {
+				// break: true prevents
+				if(breakOnTimeout && timedOut && !resetEnd) {
+					this.end = oldEnd;
+					this.errors.length = 0;
+					resetEnd = true;
+
+				}
 			},
 
 			plugins: [timeoutZone]
 		};
 	};
 };
+
+module.exports = debugZone;
 
 var taskNameMap = {
 	then: "Promise"

--- a/register.js
+++ b/register.js
@@ -44,7 +44,7 @@
 	wrapAll(g);
 
 	if(g.Promise) {
-		monitor(g, "Promise", "Promise.prototype.then");
+		monitor(g, "Promise", "Promise.prototype.then", g);
 	}
 
 	function extract(obj, prop) {
@@ -107,7 +107,7 @@
 		object[property] = wrappedFn;
 	}
 
-	function monitor(object, property, thingToRewrap) {
+	function monitor(object, property, thingToRewrap, global) {
 		var current = object[property];
 
 		Object.defineProperty(object, property, {
@@ -122,8 +122,8 @@
 					var results = extract(object, thingToRewrap);
 					var localObject = results[0];
 					var localProperty = results[1];
-					wrapInZone(localObject, localProperty);
-					monitor(object, property, thingToRewrap);
+					wrapInZone(localObject, localProperty, null, global);
+					monitor(object, property, thingToRewrap, global);
 				}
 			}
 		});

--- a/test/debug_test.js
+++ b/test/debug_test.js
@@ -52,7 +52,7 @@ describe("Debug Zone", function(){
 		});
 
 		it("Sets a breakpoint", function(done){
-			var num = 0;
+			var num = 0, end = false;
 			var checkTimeout = function(){
 				var timedOut = false;
 				// Wait for the timeout, then count up to 5 afterTasks.
@@ -65,6 +65,7 @@ describe("Debug Zone", function(){
 						if(timedOut) {
 							num++;
 							if(num === 5) {
+								console.log("ENDING");
 								zone.end();
 							}
 						}
@@ -79,7 +80,9 @@ describe("Debug Zone", function(){
 			.run(function(){
 				// An infinite loop
 				function doWork() {
-					setTimeout(doWork, 20);
+					if(!end) {
+						setTimeout(doWork, 20);
+					}
 				}
 				doWork();
 			})
@@ -89,6 +92,7 @@ describe("Debug Zone", function(){
 			.then(function(){
 				// Wait another 20, the inner setTimeout to fire.
 				setTimeout(function(){
+					end = true;
 					done();
 				}, 20);
 			}, done);

--- a/test/demo/break.html
+++ b/test/demo/break.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<title>{break:true} Demo</title>
+
+<script src="../../node_modules/steal/steal.js" main="@empty"></script>
+<script type="steal-module">
+	var Zone = require("can-zone");
+	var debug = require("can-zone/debug");
+
+	var zone = new Zone([
+		debug(5000, { break: true })
+	]);
+
+	zone.run(function(){
+		doWork();
+	})
+	.then(function(){
+		console.log("DONE!");
+	})
+	.catch(function(errors){
+		console.error(`Timeout of ${errors.timeout}`);
+	})
+
+	function doWork() {
+		var foo = "bar";
+		var baz = "qux";
+		setTimeout(doWork, 500);
+	}
+</script>


### PR DESCRIPTION
This implements a new option in the debug zone
(`require("can-zone/debug");`): {break: true}

This option enables a breakpoint to occur *after* the Zone has timed
out. A `debugger;` is placed within a function that you can easily step
into to see the code that is preventing the Zone to complete.

Closes #148