### PR TITLE
fix: allow third-party library to also wrap events in strict-mode

### DIFF
--- a/register.js
+++ b/register.js
@@ -118,6 +118,7 @@
 		} else {
 			fn = fn ? fn(object[property]) : object[property];
 			descriptor.value = wrappedFn;
+			descriptor.writable = true;	// fix: allow third-party libraries to also wrap functions
 		}
 
 		Object.defineProperty(object, property, descriptor);

--- a/test/test.js
+++ b/test/test.js
@@ -898,6 +898,49 @@ if(isBrowser) {
 		});
 	});
 
+	describe("when third-party library (i.e. affirm) also wraps events (i.e. addEventListener) in strict-mode", function(){
+		it("should execute can-zone and third-party function", function(done){
+			"use strict";	// enable throwing TypeError-exception when assigning to non-writable property
+
+			// store copy of original-addEventListener
+			var orig = Node.prototype.addEventListener;
+
+			// used to check that original function executed
+			var originalCounter = 0;
+			// used to check that third-party function executed
+			var thirdPartyCounter = 0;
+
+			// create a Node object
+			var el = document.createElement("div");
+
+			// third-party library wrapping addEventListener()
+			el.addEventListener = function(event, func, useCapture){
+				// increment counter to check that third-party funciton executed
+				thirdPartyCounter++;
+				// third-party library calls original-addEventListener
+				orig.call(this, event, func, useCapture);
+			};
+
+			new Zone().run(function(){
+				// canjs-app setting-up a addEventListener-event
+				el.addEventListener("some-event", function(){
+					// increment counter to check that original funciton executed
+					originalCounter++;
+				});
+				el.dispatchEvent(new Event("some-event"));
+			}).then(function(data){
+				// original-addEventListener worked
+				assert(originalCounter === 1, "original worked");
+				// third-party function worked
+				assert(thirdPartyCounter === 1, "third-party worked");
+
+				// restore addEventListener to original-addEventListener
+				Node.prototype.addEventListener = orig;
+			})
+			.then(done, done);
+		});
+	});
+
 	describe("onclick event handler", function() {
 		it("is run within a zone", function() {
 			this.timeout(2000);


### PR DESCRIPTION
we are using a third-party library (i.e. https://cdn1-sandbox.affirm.com/js/v2/affirm.js ) that wraps `addEventListener` that is throwing a TypeError-exception (in javascript script-mode) since `can-zone@0.6.17`.

the TypeError-exception that i am seeing (in chrome-browser) is...
```
TypeError: Cannot assign to read only property 'addEventListener' of object '#<HTMLDivElement>'
```

`can-zone@0.6.17` switched from simple-assignment to `Object.defineProperty()` (in `register.js`) but did not enable the `writable`-flag, so the third-party library could not also wrap `addEventListener` in strict-mode.