### PR TITLE
Allow can-zone to run in Worker contexts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,7 @@
 end_of_line = LF
 indent_style = tab
 indent_size = 4
+
+[{*.json,*.yml,*.md}]
+indent_style = space
+indent_size = 2

--- a/lib/env.js
+++ b/lib/env.js
@@ -8,11 +8,13 @@ var isNW = isNode && (function(){
 	return false;
   }
 })();
-var g = typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope ?
+var isWorker = typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope;
+var g = isWorker ?
 	self :
 	isNW ? window :
 	isNode ? global : window;
 
 exports.isNode = isNode;
 exports.isNW = isNW;
+exports.isWorker = isWorker;
 exports.global = g;

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -41,8 +41,11 @@ var removeTimer = function(timeoutId, callback, Zone){
 
 var getGlobalEventHandlersNames = function getGlobalEventHandlersNames() {
 	var names = [];
+  var isWorkerScope = typeof WorkerGlobalScope !== "undefined" &&
+                      typeof self !== "undefined" &&
+                      self instanceof WorkerGlobalScope;
 
-	if (!env.isNode) {
+	if (!env.isNode && !isWorkerScope) {
 		names = Object.getOwnPropertyNames(HTMLElement.prototype).filter(
 			function isGlobalEventHandler(name) {
 				return name.substr(0, 2) === "on";

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -2,6 +2,10 @@ var env = require("./env");
 var util = require("./util");
 var slice = Array.prototype.slice;
 
+var isWorker = typeof WorkerGlobalScope !== "undefined" &&
+              typeof self !== "undefined" &&
+              self instanceof WorkerGlobalScope;
+
 if(env.isNode) {
 	var globalTimeoutId = 1;
 }
@@ -41,11 +45,8 @@ var removeTimer = function(timeoutId, callback, Zone){
 
 var getGlobalEventHandlersNames = function getGlobalEventHandlersNames() {
 	var names = [];
-  var isWorkerScope = typeof WorkerGlobalScope !== "undefined" &&
-                      typeof self !== "undefined" &&
-                      self instanceof WorkerGlobalScope;
 
-	if (!env.isNode && !isWorkerScope) {
+	if (!env.isNode && !isWorker) {
 		names = Object.getOwnPropertyNames(HTMLElement.prototype).filter(
 			function isGlobalEventHandler(name) {
 				return name.substr(0, 2) === "on";

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:node": "mocha test/test.js && mocha test/test_register_node.js",
     "test:browser": "testee test/test.html test/register.html --browsers firefox --reporter Spec",
     "test:win": "testee test/test.html --browsers firefox --reporter Spec",
+    "test:worker": "testee test/test_worker.html --browsers firefox --report Spec",
     "test:xss": "mocha test/xss/test.js",
     "test": "npm run detect-cycle && npm run test:node && npm run test:browser && npm run test:xss",
     "version": "git commit -am \"Update dist for release\" && git checkout -b release && git add -f dist/",

--- a/register.js
+++ b/register.js
@@ -1,9 +1,9 @@
 "format cjs";
 (function(){
 	var isNode = typeof process !== "undefined" && {}.toString.call(process) === "[object process]";
-  var isWorker =  typeof WorkerGlobalScope !== "undefined" &&
-                  typeof self !== "undefined" &&
-                  self instanceof WorkerGlobalScope;
+	var isWorker =  typeof WorkerGlobalScope !== "undefined" &&
+			            typeof self !== "undefined" &&
+			            self instanceof WorkerGlobalScope;
 	var g = typeof WorkerGlobalScope !== "undefined" && (self instanceof WorkerGlobalScope)
 		? self
 		: isNode
@@ -136,17 +136,17 @@
 
 	// Returns an array of global event handlers names
 	// https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers
-  function getGlobalEventHandlersNames() {
-    var names = [];
+	function getGlobalEventHandlersNames() {
+		var names = [];
 
-    if (!isNode && !isWorker) {
-      names = Object.getOwnPropertyNames(HTMLElement.prototype).filter(
-        isGlobalEventHandler
-      );
-    }
+		if (!isNode && !isWorker) {
+			names = Object.getOwnPropertyNames(HTMLElement.prototype).filter(
+			  isGlobalEventHandler
+			);
+		}
 
-    return names;
-  };
+		return names;
+	};
 
 	function monitor(object, property, thingToRewrap, global) {
 		var current = object[property];

--- a/register.js
+++ b/register.js
@@ -1,9 +1,9 @@
 "format cjs";
 (function(){
 	var isNode = typeof process !== "undefined" && {}.toString.call(process) === "[object process]";
-	var isWorker =  typeof WorkerGlobalScope !== "undefined" &&
-			            typeof self !== "undefined" &&
-			            self instanceof WorkerGlobalScope;
+	var isWorker = typeof WorkerGlobalScope !== "undefined" &&
+		typeof self !== "undefined" &&
+		self instanceof WorkerGlobalScope;
 	var g = typeof WorkerGlobalScope !== "undefined" && (self instanceof WorkerGlobalScope)
 		? self
 		: isNode
@@ -141,7 +141,7 @@
 
 		if (!isNode && !isWorker) {
 			names = Object.getOwnPropertyNames(HTMLElement.prototype).filter(
-			  isGlobalEventHandler
+				isGlobalEventHandler
 			);
 		}
 

--- a/register.js
+++ b/register.js
@@ -133,17 +133,22 @@
 
 	// Returns an array of global event handlers names
 	// https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers
-	function getGlobalEventHandlersNames() {
-		var names = [];
+  function getGlobalEventHandlersNames() {
+    var names = [];
+    var isWorkerScope = typeof WorkerGlobalScope !== "undefined" &&
+                        typeof self !== "undefined" &&
+                        self instanceof WorkerGlobalScope;
 
-		if (!isNode) {
-			names =  Object.getOwnPropertyNames(HTMLElement.prototype).filter(
-				isGlobalEventHandler
-			);
-		}
+    if (!isNode && !isWorkerScope) {
+      names = Object.getOwnPropertyNames(HTMLElement.prototype).filter(
+        function isGlobalEventHandler(name) {
+          return name.substr(0, 2) === "on";
+        }
+      );
+    }
 
-		return names;
-	}
+    return names;
+  };
 
 	function monitor(object, property, thingToRewrap, global) {
 		var current = object[property];

--- a/register.js
+++ b/register.js
@@ -146,7 +146,7 @@
 		}
 
 		return names;
-	};
+	}
 
 	function monitor(object, property, thingToRewrap, global) {
 		var current = object[property];

--- a/register.js
+++ b/register.js
@@ -1,6 +1,9 @@
 "format cjs";
 (function(){
 	var isNode = typeof process !== "undefined" && {}.toString.call(process) === "[object process]";
+  var isWorker =  typeof WorkerGlobalScope !== "undefined" &&
+                  typeof self !== "undefined" &&
+                  self instanceof WorkerGlobalScope;
 	var g = typeof WorkerGlobalScope !== "undefined" && (self instanceof WorkerGlobalScope)
 		? self
 		: isNode
@@ -135,15 +138,10 @@
 	// https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers
   function getGlobalEventHandlersNames() {
     var names = [];
-    var isWorkerScope = typeof WorkerGlobalScope !== "undefined" &&
-                        typeof self !== "undefined" &&
-                        self instanceof WorkerGlobalScope;
 
-    if (!isNode && !isWorkerScope) {
+    if (!isNode && !isWorker) {
       names = Object.getOwnPropertyNames(HTMLElement.prototype).filter(
-        function isGlobalEventHandler(name) {
-          return name.substr(0, 2) === "on";
-        }
+        isGlobalEventHandler
       );
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@ var Zone = require("../lib/zone");
 var env = require("../lib/env");
 
 var isNode = env.isNode;
+var isWorker = env.isWorker;
 
 if(!isNode) {
 	require("steal-mocha");
@@ -568,7 +569,7 @@ describe("nested setTimeouts", function(){
 
 });
 
-if(isBrowser) {
+if(isBrowser && !isWorker) {
 	describe("requestAnimationFrame", function(){
 		it("setTimeout with requestAnimationFrame", function(done){
 			var results = [];
@@ -850,7 +851,7 @@ if(supportsMutationObservers) {
 	});
 }
 
-if(isBrowser) {
+if(isBrowser && !isWorker) {
 	describe("addEventListener", function(){
 		it("is run within a zone", function(done){
 			this.timeout(2000);

--- a/test/test_worker.html
+++ b/test/test_worker.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<title>can-zone tests</title>
+<meta charset="UTF-8">
+<script src="../node_modules/steal/steal.js" main="test/test_worker"
+	data-mocha="bdd" data-transpiler="babel"></script>

--- a/test/test_worker.js
+++ b/test/test_worker.js
@@ -1,0 +1,73 @@
+var steal = require("@steal");
+var mocha = require("steal-mocha");
+var assert = require("assert");
+
+
+var workerUrl = steal.loader.stealURL + "?main=~/test/worker_main";
+var worker = new Worker(workerUrl);
+
+worker.addEventListener("message", function onMsg(ev){
+	var msg = ev.data;
+
+	switch(msg.type) {
+		case "suites":
+			defineSuites(ev.data.suites);
+			break;
+		case "test":
+			setTestResults(ev.data);
+			break;
+	}
+});
+
+var testMap = new Map();
+
+function clearUI() {
+	var stats = document.getElementById("mocha-stats");
+	var report = document.getElementById("mocha-report");
+	stats.parentNode.removeChild(stats);
+	report.parentNode.removeChild(report);
+}
+
+function defineSuites(suites) {
+	clearUI();
+
+	suites.forEach(function(suite){
+		suite.tests.forEach(function(test){
+			var dfd = {};
+			dfd.promise = new Promise(function(resolve){
+				dfd.resolve = resolve;
+			});
+			var key = suite.title + " - " + test.title;
+			testMap.set(key, dfd);
+		});
+
+		describe(suite.title, function(){
+			suite.tests.forEach(function(test){
+				it(test.title, function(done) {
+					var key = suite.title + " - " + test.title;
+					testMap.get(key).resolve(done);
+				});
+			})
+		})
+	});
+
+	mocha.run();
+}
+
+function setTestResults(msg) {
+	var key = msg.suite + " - " + msg.title;
+	var dfd = testMap.get(key);
+
+	if(dfd) {
+		dfd.promise.then(function(done){
+			assert.equal(msg.state, "passed");
+
+			if(typeof done === "undefined") {
+				debugger;
+			}
+
+			done();
+		});
+	}
+
+}

--- a/test/worker_main.js
+++ b/test/worker_main.js
@@ -1,0 +1,15 @@
+var steal = require("@steal");
+
+steal.config({
+	map: {
+		"steal-mocha": "node_modules/mocha/mocha"
+	},
+	meta: {
+		"node_modules/mocha/mocha": {
+		   "format": "global",
+		   "exports": "mocha"
+		}
+	}
+});
+
+steal.import("~/test/worker_test");

--- a/test/worker_test.js
+++ b/test/worker_test.js
@@ -1,0 +1,42 @@
+var mocha = require("steal-mocha");
+
+mocha.setup({
+  ui: 'bdd',
+  reporter: null,
+});
+
+require("./test");
+
+var runResults = mocha.run();
+
+var suiteInfo = runResults.suite.suites.map(function(suite){
+	return {
+		title: suite.title,
+		tests: suite.tests.map(function(test){
+			return {
+				title: test.title
+			}
+		})
+	};
+});
+
+postMessage({
+	type: "suites",
+	suites: suiteInfo
+});
+
+runResults.on("test end", function(test) {
+	postMessage({
+		type: "test",
+		title: test.title,
+		state: test.state,
+		suite: test.parent.title
+	});
+});
+
+runResults.on("end", function() {
+	postMessage({
+		type: "run end"
+	});
+  //console.log(`${runResults.failures} out of ${runResults.total} failures.`);
+});


### PR DESCRIPTION
Ignore trying to get event listeners from `HTMLElement.prototype` when in a Worker context (no window/document/elements) similar to when running in a Node context.

@matthewp should we return `onmessage` for the worker global context?