### PR TITLE
Handle cases where onreadstatechange / onload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 doc/
 test/xss/out.html
+.DS_Store

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -219,7 +219,7 @@ exports.send = function(send, Zone){
 				}
 			};
 
-			var parentDesc = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this), "onreadystatechange");
+			this.onreadystatechange = ourReadystatechange;
 
 			Object.defineProperty(this, "onreadystatechange", {
 				enumerable: true,
@@ -232,10 +232,6 @@ exports.send = function(send, Zone){
 					callback = createCallback(onreadystatechange);
 				}
 			});
-
-			if(parentDesc && parentDesc.set) {
-				parentDesc.set.call(this, ourReadystatechange);
-			}
 		}
 
 		function createCallback(fn){

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -205,15 +205,37 @@ exports.send = function(send, Zone){
 		} else {
 			onreadystatechange = onreadystatechange || function(){};
 			var callback = createCallback(onreadystatechange);
-			this.onreadystatechange = function(ev){
+
+			var ourReadystatechange = function(ev) {
 				var xhr = ev ? ev.target : thisXhr;
 
 				if(xhr.readyState === 4) {
 					return callback.apply(this, arguments);
 				} else {
+					if(xhr.onload) {
+						xhr.onload(ev);
+					}
 					return onreadystatechange.apply(this, arguments);
 				}
 			};
+
+			var parentDesc = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this), "onreadystatechange");
+
+			Object.defineProperty(this, "onreadystatechange", {
+				enumerable: true,
+				configurable: true,
+				get: function() {
+					return ourReadystatechange;
+				},
+				set: function(newFn) {
+					onreadystatechange = newFn;
+					callback = createCallback(onreadystatechange);
+				}
+			});
+
+			if(parentDesc && parentDesc.set) {
+				parentDesc.set.call(this, ourReadystatechange);
+			}
 		}
 
 		function createCallback(fn){

--- a/test/test.js
+++ b/test/test.js
@@ -510,7 +510,43 @@ if(isBrowser) {
 				})
 				.then(done);
 			});
+
+			it("can be set after send() is called", function(done) {
+				var zone = new Zone();
+				zone.run(function(d){
+					var xhr = new XMLHttpRequest();
+					xhr.open("GET", "http://chat.donejs.com/api/messages");
+					xhr.send();
+					xhr.onload = function(){
+						zone.data.worked = true;
+					};
+				})
+				.then(function(data){
+					assert.equal(data.worked, true);
+				})
+				.then(done);
+			});
 		});
+
+		describe("onreadystatechange", function(){
+			it("can be set after send() is called", function(done) {
+				var zone = new Zone();
+				zone.run(function(d){
+					var xhr = new XMLHttpRequest();
+					xhr.open("GET", "http://chat.donejs.com/api/messages");
+					xhr.send();
+					xhr.onreadystatechange = function(){
+						if(xhr.readyState === 4) {
+							zone.data.worked = true;
+						}
+					};
+				})
+				.then(function(data){
+					assert.equal(data.worked, true);
+				})
+				.then(done);
+			});
+		})
 
 		it("can run a Promise within the callback", function(done){
 			var zone = new Zone();


### PR DESCRIPTION
Are set *after* send() is called. We do this by creating a getter/setter
pair and capturing when the properties are set. Fixes #183