### PR TITLE
Add onloadend handler for zoned XHRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - 7
+  - 14
 script: 'npm run test:node'
 dist: xenial
 services:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 # Test against this version of Node.js
 environment:
-  DEBUG: launchpad:local:browser
   matrix:
   # node.js
   - nodejs_version: "10"
@@ -9,8 +8,6 @@ environment:
 
 # Install scripts. (runs after repo cloning)
 install:
-  # Get latest firefox
-  - choco install firefox
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
   # install modules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,8 @@ environment:
 
 # Install scripts. (runs after repo cloning)
 install:
+  # Get latest firefox
+  - choco install firefox
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
   # install modules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ test_script:
   - node --version
   - npm --version
   # run tests
+  - set PROGRAMFILES=%PROGRAMFILES(X86)%
   - npm run test:node
   - npm run test:win
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 # Test against this version of Node.js
 environment:
+  DEBUG: launchpad:local:browser
   matrix:
   # node.js
   - nodejs_version: "10"
@@ -21,7 +22,6 @@ test_script:
   - node --version
   - npm --version
   # run tests
-  - set PROGRAMFILES=%PROGRAMFILES(X86)%
   - npm run test:node
   - npm run test:win
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,9 @@
 environment:
   matrix:
   # node.js
-  - nodejs_version: "8"
   - nodejs_version: "10"
+  - nodejs_version: "12"
+  - nodejs_version: "14"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -193,6 +193,7 @@ exports.send = function(send, Zone){
 	return function(){
 		var onreadystatechange = this.onreadystatechange,
 			onload = this.onload,
+			onloadend = this.onloadend,
 			onerror = this.onerror,
 			thisXhr = this,
 			zone = Zone.current;
@@ -201,6 +202,7 @@ exports.send = function(send, Zone){
 
 		if(supportsOnload && this.onload) {
 			this.onload = createCallback(onload);
+			this.onloadend = createCallback(onloadend);
 			this.onerror = createCallback(onerror);
 		} else {
 			onreadystatechange = onreadystatechange || function(){};
@@ -214,6 +216,9 @@ exports.send = function(send, Zone){
 				} else {
 					if(xhr.onload) {
 						xhr.onload(ev);
+					}
+					if(xhr.onloadend) {
+						xhr.onloadend(ev);
 					}
 					return onreadystatechange.apply(this, arguments);
 				}

--- a/lib/zones/xhr.js
+++ b/lib/zones/xhr.js
@@ -42,12 +42,14 @@ function browserZone(data){
 		}
 		if(response) {
 			var onload = this.onload || noop;
+			var onloadend = this.onloadend || noop;
 			var onreadystatechange = this.onreadystatechange || noop;
 			var xhr = this;
 			setTimeout(function(){
 				var ev = { target: xhr };
 				onreadystatechange.call(xhr, ev);
 				onload.call(xhr, ev);
+				onloadend.call(xhr, ev);
 			}, 0);
 			return;
 		}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "steal": "^2.1.7",
     "steal-mocha": "^1.0.0",
     "steal-tools": "^2.0.7",
-    "testee": "^0.9.0"
+    "testee": "^0.10.2"
   },
   "steal": {
     "npmDependencies": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "document": "bit-docs",
     "test:node": "mocha test/test.js && mocha test/test_register_node.js",
     "test:browser": "testee test/test.html test/register.html --browsers firefox --reporter Spec",
-    "test:win": "testee test/test.html --browsers firefox --reporter Spec",
+    "test:win": "testee test/test.html --browsers chrome --reporter Spec",
     "test:worker": "testee test/test_worker.html --browsers firefox --report Spec",
     "test:xss": "mocha test/xss/test.js",
     "test": "npm run detect-cycle && npm run test:node && npm run test:browser && npm run test:xss",

--- a/test/test.js
+++ b/test/test.js
@@ -566,7 +566,25 @@ if(isBrowser) {
 				})
 				.then(done);
 			});
-		})
+		});
+
+		describe("onloadend", function() {
+			it("can be set after send() is called", function(done) {
+				var zone = new Zone();
+				zone.run(function(d){
+					var xhr = new XMLHttpRequest();
+					xhr.open("GET", "http://chat.donejs.com/api/messages");
+					xhr.send();
+					xhr.onloadend = function(){
+						zone.data.worked = true;
+					};
+				})
+				.then(function(data){
+					assert.equal(data.worked, true);
+				})
+				.then(done);
+			});
+		});
 
 		it("can run a Promise within the callback", function(done){
 			var zone = new Zone();

--- a/test/xhr.js
+++ b/test/xhr.js
@@ -167,6 +167,29 @@ if(env.isNode) {
 				})
 				.then(done, done);
 			});
+
+			it("Loads data from the cache when using onloadend", function(done) {
+				function app() {
+					Promise.resolve().then(function(){
+						return new Promise(function(resolve, reject){
+							var xhr = new XMLHttpRequest();
+							xhr.open("GET", "foo://bar");
+							xhr.onloadend = function(){
+								resolve();
+							};
+							xhr.send();
+						});
+					})
+					.then(function(){
+						Zone.current.data.worked = true;
+					});
+				}
+
+				new Zone(xhrZone).run(app).then(function(data){
+					assert.equal(data.worked, true);
+				})
+				.then(done, done);
+			});
 		});
 
 		describe("URLs relative to server (i.e. done-ssr proxy-request)", function(){


### PR DESCRIPTION
Axios subscribes to the onloadend handler on XHRs rather than the onload or onreadystatechange handler, which causes problems if an XHR request has been intercepted by can-zone.  The XHR zone does not currently fire this handler when pulling a response out of XHR_CACHE.

This PR adds onloadend to the callbacks fired in the XHR zone to fix the above issue.