### PR TITLE
Support fetch in zones, and create a fetch zone to capture/replay responses like XHR zone

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@
 environment:
   matrix:
   # node.js
-  - nodejs_version: "10"
   - nodejs_version: "12"
   - nodejs_version: "14"
 

--- a/fetch.js
+++ b/fetch.js
@@ -1,0 +1,2 @@
+"use strict";
+module.exports = require("./lib/zones/fetch");

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -262,6 +262,22 @@ exports.nextTick = function(nextTick, Zone){
 	};
 };
 
+exports.fetch = function(fetch, Zone){
+	return function(){
+		var zone = Zone.current;
+		zone.addWait();
+		var promise = fetch.apply(null, arguments);
+		promise.then(function(response) {
+			zone.removeWait();
+			return response;
+		}, function(err) {
+			zone.removeWait();
+			throw err;
+		})
+		return promise;
+	};
+};
+
 exports.MutationObserver = function(MutationObserver, Zone){
 	return function(fn){
 		fn = Zone.current.wrap(fn);

--- a/lib/zones/fetch.js
+++ b/lib/zones/fetch.js
@@ -4,8 +4,6 @@ var util = require("../util");
 
 module.exports = env.isNode ? nodeZone : browserZone;
 
-var WAIT_URL = util.symbol("__canWaitURL");
-
 function browserZone(data){
 	var cache, oldFetch;
 	var noop = Function.prototype;
@@ -31,12 +29,6 @@ function browserZone(data){
 				response = data.response;
 				cache.splice(i, 1);
 				break;
-			}
-		}
-
-		function ensureReadable(name, used) {
-			if(used) { 
-				throw new Error(`Failed to execute '${name}' on 'Response': body stream already read`);
 			}
 		}
 

--- a/lib/zones/fetch.js
+++ b/lib/zones/fetch.js
@@ -121,9 +121,9 @@ function nodeZone(data){
 
 var escapeTable = {
 	"<": "\\u003c",
-		">": "\\u003e",
-		"&": "\\u0026",
-		"=": "\\u003d"
+	">": "\\u003e",
+	"&": "\\u0026",
+	"=": "\\u003d"
 };
 
 var escapeRegExp = new RegExp(

--- a/lib/zones/fetch.js
+++ b/lib/zones/fetch.js
@@ -1,0 +1,152 @@
+"use strict";
+var env = require("../env");
+var util = require("../util");
+
+module.exports = env.isNode ? nodeZone : browserZone;
+
+var WAIT_URL = util.symbol("__canWaitURL");
+
+function browserZone(data){
+	var cache, oldFetch;
+	var noop = Function.prototype;
+
+	var matches = function(request, url, body) {
+		var requestURL = request.url;
+		// check if url is relative to server (i.e. /bar) instead of absolute url (i.e. http://foo/bar) so that done-ssr proxy-request will match on client-side
+		if (url.substr(0, 1) === '/') {
+			// strip everything before pathname to match url relative to server
+			requestURL = requestURL.replace(/^\w*:\/{2}[^\/]+\//i, '/');
+		}
+		return (requestURL === url) &&
+			(!body || request.data === body);
+	};
+
+	function stubFetch(url, options) {
+		var response, stubResponse;
+		options = options || {};
+
+		for(var i = 0, len = cache.length; i < len; i++) {
+			data = cache[i];
+			if(matches(data.request, url, options.body)) {
+				response = data.response;
+				cache.splice(i, 1);
+				break;
+			}
+		}
+
+		function ensureReadable(name, used) {
+			if(used) { 
+				throw new Error(`Failed to execute '${name}' on 'Response': body stream already read`);
+			}
+		}
+
+		if(response) {
+			stubResponse = new Response(
+				response.responseText,
+				{
+					status: 200,
+					statusText: "OK"
+				}
+			)
+
+			util.defineProperty(response, "url", {
+				value: url
+			});
+
+			return Promise.resolve(stubResponse);
+		} else {
+			return oldFetch(url, options);
+		}
+	}
+
+
+	return {
+		beforeTask: function(){
+			cache = env.global.FETCH_CACHE;
+			if(cache) {
+				oldFetch = fetch;
+				global.fetch = stubFetch;
+			}
+		},
+
+		afterTask: function(){
+			if(oldFetch) {
+				fetch = oldFetch;
+				oldFetch = null;
+			}
+		}
+	};
+}
+
+function nodeZone(data){
+	var oldFetch;
+
+	function stubFetch(url, options) {
+		return oldFetch(url, options).then(function(response) {
+			var cloneResponse = response.clone();
+
+			var headers = {};
+			cloneResponse.headers.forEach(function(header) {
+				var key = header.key;
+				var value = header.value;
+				headers[key] = value;
+			})
+
+			cloneResponse.text().then(function(respBody) {
+				if(!data.fetch) {
+					data.fetch = new Fetch();
+				}
+				data.fetch.data.push({
+					request: {
+						url: url,
+						data: options.body
+					},
+					response: {
+						status: cloneResponse.status,
+						responseText: respBody,
+						headers: headers
+					}
+				});
+			});
+
+			return response;
+		});
+	}
+
+	return {
+		beforeTask: function(){
+			oldFetch = fetch;
+			global.fetch = stubFetch;
+		},
+		afterTask: function(){
+			if(oldFetch) {
+				global.fetch = oldFetch;
+				oldFetch = null;
+			}
+		}
+	};
+}
+
+var escapeTable = {
+	"<": "\\u003c",
+		">": "\\u003e",
+		"&": "\\u0026",
+		"=": "\\u003d"
+};
+
+var escapeRegExp = new RegExp(
+	"(" +
+	Object.keys(escapeTable).join("|") +
+	")", "g");
+
+function Fetch(){
+	this.data = [];
+}
+
+Fetch.prototype.toString = function(){
+	var json = JSON.stringify(this.data);
+	json = json.replace(escapeRegExp, function(m){
+		return escapeTable[m];
+	});
+	return "FETCH_CACHE = " + json + ";";
+};

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "chai": "^4.0.1",
     "detect-cyclic-packages": "^1.1.0",
     "mocha": "^4.0.0",
+    "node-fetch-commonjs": "^3.2.4",
     "steal": "^2.1.7",
     "steal-mocha": "^1.0.0",
     "steal-tools": "^2.0.7",
@@ -65,7 +66,14 @@
     },
     "plugins": [
       "chai"
-    ]
+    ],
+    "envs": {
+      "window-development": {
+        "map": {
+          "node-fetch-commonjs": "@empty"
+        }
+      }
+    }
   },
   "bit-docs": {
     "dependencies": {

--- a/register.js
+++ b/register.js
@@ -33,6 +33,7 @@
 			"Node.prototype.addEventListener",
 			"Node.prototype.removeEventListener",
 			"process.nextTick",
+			"fetch",
 			"setImmediate",
 			"clearImmediate",
 			{

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -1,0 +1,252 @@
+var assert = require("assert");
+var env = require("../lib/env");
+var g = env.global;
+var Zone = require("../lib/zone");
+var fetchZone = require("../fetch");
+var oldFetch = g.fetch || require("node-fetch-commonjs");
+
+if(env.isNode) {
+	describe("Fetch Zone in Node", function(){
+		beforeEach(function(){
+			var globalSetTimeout = g.setTimeout;
+			var Response = g.Response || oldFetch.Response
+			var fetch = g.fetch = function(){
+				return Promise.resolve(
+					new Response('{"foo":"bar"}')
+				);
+			};
+		});
+
+		afterEach(function(){
+			g.fetch = oldFetch;
+		});
+
+		it("Can be called multiple times", function(done){
+			var zone = new Zone({
+				plugins: [fetchZone]
+			});
+
+			var firstRun = zone.run(function(){
+				fetch("http://example.com");
+			}).then(function(data){
+				assert(data.fetch.toString().length, "got the fetch object");
+			});
+
+			firstRun.then(function(){
+				zone = new Zone({
+					plugins: [fetchZone]
+				});
+
+				return zone.run(function(){
+					fetch("http://example.com");
+				}).then(function(data){
+					assert(data.fetch.toString().length, "got the fetch object");
+				});
+			}).then(done, done);
+		});
+
+		describe("POST", function(){
+			it("Multiple requests to the same URL results in multiple entries", function(done){
+				var zone = new Zone({
+					plugins: [fetchZone]
+				}).run(function(){
+					function api(data) {
+						var f = fetch("http://example.com", {
+							method: "post",
+							body: JSON.stringify(data)
+						});
+						return new Promise(function(resolve){
+							f.then(resolve);
+						});
+					}
+
+
+					api({one:1}).then(function(){
+						return api({two:2});
+					});
+
+				}).then(function(data){
+					var cache = data.fetch.toString();
+					assert.ok(/{\\"one\\"/.test(cache), "got the first post");
+					assert.ok(/{\\"two\\"/.test(cache), "got the second post");
+				}).then(done, done);
+			});
+		});
+	});
+} else {
+	describe("Fetch Zone in the Browser", function(){
+		describe("Basics", function(){
+			beforeEach(function(){
+				g.FETCH_CACHE = [
+					{ request: { url: "foo://bar" },
+						response: { responseText: '{"foo": "bar"}',
+							headers: "application/json" } },
+					{ request: { url: "baz://qux" },
+						response: { responseText: '{"baz": "qux"}',
+							headers: "application/json" } }
+				];
+			});
+
+			afterEach(function(){
+				delete g.FETCH_CACHE;
+			});
+
+			it("Loads data from the cache", function(done){
+				function app(){
+					assert.equal(g.FETCH_CACHE.length, 2,
+								 "There are 2 items in the cache");
+
+					fetch("foo://bar").then(
+						function(firstResponse){
+							return firstResponse.json();
+						}).then(function(firstResponseBody) {
+							Zone.current.data.first = firstResponseBody;
+							assert.equal(g.FETCH_CACHE.length, 1,
+										 "There is one item in the cache");
+						});
+
+					setTimeout(function(){
+						fetch("baz://qux").then(function(secondResponse) {
+							return secondResponse.json();
+						}).then(function(secondResponseBody){
+							Zone.current.data.second = secondResponseBody;
+							assert.equal(g.FETCH_CACHE.length, 0,
+										 "The cache is empty");
+						});
+					}, 30);
+				}
+
+				new Zone(fetchZone).run(app).then(function(data){
+					assert.equal(data.first.foo, "bar", "got the first response");
+					assert.equal(data.second.baz, "qux", "got the second response");
+				}).then(done, done);
+			});
+		});
+
+		describe("URLs relative to server (i.e. done-ssr proxy-request)", function(){
+			beforeEach(function(){
+				g.FETCH_CACHE = [
+					{ request: { url: "foo://bar/abc" },
+						response: { responseText: '{"foo": "bar"}',
+							headers: "application/json" } },
+					{ request: { url: "foo://bar/abc/def" },
+						response: { responseText: '{"baz": "qux"}',
+							headers: "application/json" } }
+				];
+			});
+
+			afterEach(function(){
+				delete g.FETCH_CACHE;
+			});
+
+			it("Loads data from the cache", function(done){
+				function app(){
+					assert.equal(g.FETCH_CACHE.length, 2,
+								 "There are 2 items in the cache");
+
+					fetch("/abc").then(function(firstResponse) {
+						return firstResponse.json();
+					}).then(function(firstResponseBody){
+						Zone.current.data.first = firstResponseBody;
+						assert.equal(g.FETCH_CACHE.length, 1,
+									 "There is one item in the cache");
+					});
+
+					setTimeout(function(){
+						fetch("/abc/def").then(function(secondResponse) {
+							return secondResponse.json();
+						}).then(function(secondResponseBody){
+							Zone.current.data.second = secondResponseBody;
+							assert.equal(g.FETCH_CACHE.length, 0,
+										 "The cache is empty");
+						});
+					}, 30);
+				}
+
+				new Zone(fetchZone).run(app).then(function(data){
+					assert.equal(data.first.foo, "bar", "got the first response");
+					assert.equal(data.second.baz, "qux", "got the second response");
+				}).then(done, done);
+			});
+		});
+
+		describe("POST with multiple requests from the same URL", function(){
+			beforeEach(function(){
+				g.FETCH_CACHE = [
+					{ request: { url: "foo://bar", data:"{\"one\":1}" },
+						response: { responseText: '{"foo": "bar"}',
+							headers: "application/json" } },
+					{ request: { url: "foo://bar", data:"{\"two\":2}" },
+						response: { responseText: '{"baz": "qux"}',
+							headers: "application/json" } }
+				];
+			});
+
+			afterEach(function(){
+				delete g.FETCH_CACHE;
+			});
+
+			it("Loads each from the cache", function(done){
+				function app(){
+					assert.equal(g.FETCH_CACHE.length, 2,
+								 "There are 2 items in the cache");
+
+					fetch("foo://bar", {
+						method: "post",
+						body: JSON.stringify({two:2})
+					}).then(function(firstResponse) {
+						return firstResponse.json();
+					}).then(function(firstResponseBody){
+						Zone.current.data.first = firstResponseBody;
+						assert.equal(g.FETCH_CACHE.length, 1,
+									 "There is one item in the cache");
+					});
+
+					setTimeout(function(){
+						fetch("foo://bar", {
+							method: "post",
+							body: JSON.stringify({one:1})
+						}).then(function(secondResponse) {
+							return secondResponse.json();
+						}).then(function(secondResponseBody){
+							Zone.current.data.second = secondResponseBody;
+							assert.equal(g.FETCH_CACHE.length, 0,
+										 "The cache is empty");
+						});
+					}, 30);
+				}
+
+				new Zone(fetchZone).run(app).then(function(data){
+					assert.equal(data.first.baz, "qux", "got the first response");
+					assert.equal(data.second.foo, "bar", "got the second response");
+				}).then(done, done);
+			});
+		});
+
+		describe("Errors", function(){
+			beforeEach(function(){
+				g.FETCH_CACHE = [
+					{ request: { url: "foo://bar" },
+						response: { responseText: '{"foo": "bar"}',
+							status: 404,
+							headers: "application/json" } }
+				];
+			});
+
+			afterEach(function(){
+				delete g.FETCH_CACHE;
+			});
+
+
+			it("Sets the status to 404", function(done){
+				new Zone(fetchZone).run(function(){
+					fetch("foo://bar").then(function(response) {
+						assert.equal(resonse.status, 404, "Set to 404");
+					});
+				}).then(function(){
+					done();
+				}, done);
+			});
+		});
+	});
+}

--- a/test/test.js
+++ b/test/test.js
@@ -460,7 +460,7 @@ describe("setTimeout", function(){
 	});
 });
 
-describe("setTimeout and XHR", function(){
+describe("setTimeout, XHR, and fetch", function(){
 
 	if(isBrowser) {
 		it("all results returned", function(done){
@@ -482,11 +482,15 @@ describe("setTimeout and XHR", function(){
 					results.push("1-c");
 				};
 				xhr.send();
+
+				fetch("http://chat.donejs.com/api/messages").then(function() {
+					results.push("1-d");
+				})
 			}).then(function(){
 
-				assert.equal(results.length, 3, "Got 3 results");
+				assert.equal(results.length, 4, "Got 4 results" );
 
-			}).then(done);
+			}).then(done, done);
 		});
 	}
 
@@ -597,6 +601,24 @@ if(isBrowser) {
 					});
 				};
 				xhr.send();
+			}).then(function(data){
+				assert.equal(data.worked, true, "got to the then");
+			}).then(done, done);
+		});
+	});
+}
+
+if(isBrowser) {
+	describe("fetch", function(){
+		it("can run a Promise within the callback", function(done){
+			var zone = new Zone();
+			zone.run(function(){
+				fetch("http://chat.donejs.com/api/messages")
+				.then(function(){
+					Promise.resolve().then(function(){
+						Zone.current.data.worked = true;
+					});
+				});
 			}).then(function(data){
 				assert.equal(data.worked, true, "got to the then");
 			}).then(done, done);
@@ -1180,5 +1202,6 @@ describe("Zone.ignore", function(){
 
 // Require other tests
 require("./xhr");
+require("./fetch");
 require("./timeout_test");
 require("./debug_test");


### PR DESCRIPTION
Fetch is wrapped in the zone registry because, even though it should be able to take advantage of Promise.prototype.then(), zones do not wait properly unless fetch is wrapped and adds a wait.

In addiition, a fetch zone is added that captures network requests and responses exactly like how the XHR zone does.  The caches are kept separate, so the fetch cache is global.FETCH_CACHE to distinguish it from global.XHR_CACHE